### PR TITLE
awsome_guy_360 user id fixed

### DIFF
--- a/Forum_Helpers/curators.json
+++ b/Forum_Helpers/curators.json
@@ -50,7 +50,7 @@
 	
     {
 	    "name": "awsome_guy_360",
-        "id": "awsome_guy_360",
+        "id": "4677774",
         "bio": "No Biography Provided.",
         "helped_code": false
     },


### PR DESCRIPTION
After #38 was merged, I noticed that awsome_guy_360's user id was incorrect and their profile picture was not showing. This was my fault, as I pasted their username where the user id should go.