### PR TITLE
Switch from cdn2 to uploads

### DIFF
--- a/Forum_Helpers/FHP.js
+++ b/Forum_Helpers/FHP.js
@@ -14,7 +14,7 @@ man_pull.onreadystatechange = function() {
 			var man_bio = man_keyjson.bio
 			var man_add=
 			`<div class="FHP_Blocks"><h4 class="username"><a href="https://scratch.mit.edu/users/${man_username}/" class="FHULink">${man_username}</a></h4>
-			<a href="https://scratch.mit.edu/users/${man_username}/"><img src="https://cdn2.scratch.mit.edu/get_image/user/${man_userID}_60x60.png" class="pfp" loading="lazy" alt="${man_username}'s Profile Picture"></a>
+			<a href="https://scratch.mit.edu/users/${man_username}/"><img src="https://uploads.scratch.mit.edu/get_image/user/${man_userID}_60x60.png" class="pfp" loading="lazy" alt="${man_username}'s Profile Picture"></a>
 			<p class="bio">${man_bio}</p>
 			<br></div>
 			<hr>`
@@ -41,7 +41,7 @@ cur_pull.onreadystatechange = function() {
 			var cur_bio = cur_keyjson.bio
 			var cur_add=
 			`<div class="FHP_Blocks"><h4 class="username"><a href="https://scratch.mit.edu/users/${cur_username}/" class="FHULink">${cur_username}</a></h4>
-			<a href="https://scratch.mit.edu/users/${cur_username}/"><img src="https://cdn2.scratch.mit.edu/get_image/user/${cur_userID}_60x60.png" class="pfp" loading="lazy" alt="${cur_username}'s Profile Picture"></a>
+			<a href="https://scratch.mit.edu/users/${cur_username}/"><img src="https://uploads.scratch.mit.edu/get_image/user/${cur_userID}_60x60.png" class="pfp" loading="lazy" alt="${cur_username}'s Profile Picture"></a>
 			<p class="bio">${cur_bio}</p>
 			<br></div>
 			<hr>`


### PR DESCRIPTION
Switches the location where images are pulled from to uploads.scratch.mit.edu instead of cdn2.scratch.mit.edu in order to stay up to date with where Scratch is hosting images. This resolves #42 

The following things were reviewed and tested
- [x] Switch the URL for both curators and mangers inside the JS used to generate the page
- [x] Ensure that the default PFP works correctly (Scratch was having issues with that recently)
- [x] Ensure that all file types display correctly (PNG, JPG, GIF)
    - [x] Ensure that images are sized correctly (including gif images)
    - [x] PNG images should be transparent, not white in the background

@leahcimto feel free to leave a review since you were the one who created the issue.