### PR TITLE
Use JS to navigate through the list of Forum Helpers instead

### DIFF
--- a/forumhelpers/index.html
+++ b/forumhelpers/index.html
@@ -8,7 +8,7 @@
 		<meta name="Description" content="The list of all the Forum Helpers who are in the Scratch Forum Helpers studio, as well as their biographies.">
 	</head>
 
-	<body style = "margin:0">
+	<body style = "margin:0"><div id="top"></div>
 	<embed type="text/html" src="../resources/header.html" style="width:100%; height:70px; margin-bottom:-5px">
 
 
@@ -27,9 +27,9 @@
 		<br>
 		<!--<h4 style="margin-left: 10px;"><img src="/resources/coder.png" alt="coder" style="width:30px;height:30px;vertical-align:middle"> Indicates that that person has helped code the website.</h4>-->
 		<div class="forumhelpers_navblock">
-		<h3 style="text-align: center;"><a href="javascript:document.getElementById('top'     ).scrollIntoView({block:'end', behaviour:'smooth'});" class="FHULink">Top</a></h3>
-		<h3 style="text-align: center;"><a href="javascript:document.getElementById('managers').scrollIntoView({block:'end', behaviour:'smooth'});" class="FHULink">Managers</a></h3>
-		<h3 style="text-align: center;"><a href="javascript:document.getElementById('curators').scrollIntoView({block:'end', behaviour:'smooth'});" class="FHULink">Curators</a></h3>
+		<h3 style="text-align: center;"><a href="javascript:document.getElementById('top'     ).scrollIntoView();" class="FHULink">Top</a></h3>
+		<h3 style="text-align: center;"><a href="javascript:document.getElementById('managers').scrollIntoView();" class="FHULink">Managers</a></h3>
+		<h3 style="text-align: center;"><a href="javascript:document.getElementById('curators').scrollIntoView();" class="FHULink">Curators</a></h3>
 		</div>
 		
 		<!--The following ids and classes need to be changed when the JavaScript is reworked. Until then, they should stay as the old names and should not be updated to match new naming guidelines-->

--- a/forumhelpers/index.html
+++ b/forumhelpers/index.html
@@ -27,9 +27,9 @@
 		<br>
 		<!--<h4 style="margin-left: 10px;"><img src="/resources/coder.png" alt="coder" style="width:30px;height:30px;vertical-align:middle"> Indicates that that person has helped code the website.</h4>-->
 		<div class="forumhelpers_navblock">
-		<h3 style="text-align: center;"><a href="#top" class="FHULink">Top</a></h3>
-		<h3 style="text-align: center;"><a href="#managers" class="FHULink">Managers</a></h3>
-		<h3 style="text-align: center;"><a href="#curators" class="FHULink">Curators</a></h3>
+		<h3 style="text-align: center;"><a href="javascript:document.getElementById('top').scrollIntoView();" class="FHULink">Top</a></h3>
+		<h3 style="text-align: center;"><a href="javascript:document.getElementById('managers').scrollIntoView();" class="FHULink">Managers</a></h3>
+		<h3 style="text-align: center;"><a href="javascript:document.getElementById('curators').scrollIntoView();" class="FHULink">Curators</a></h3>
 		</div>
 		
 		<!--The following ids and classes need to be changed when the JavaScript is reworked. Until then, they should stay as the old names and should not be updated to match new naming guidelines-->

--- a/forumhelpers/index.html
+++ b/forumhelpers/index.html
@@ -27,9 +27,9 @@
 		<br>
 		<!--<h4 style="margin-left: 10px;"><img src="/resources/coder.png" alt="coder" style="width:30px;height:30px;vertical-align:middle"> Indicates that that person has helped code the website.</h4>-->
 		<div class="forumhelpers_navblock">
-		<h3 style="text-align: center;"><a href="javascript:document.getElementById('top').scrollIntoView();" class="FHULink">Top</a></h3>
-		<h3 style="text-align: center;"><a href="javascript:document.getElementById('managers').scrollIntoView();" class="FHULink">Managers</a></h3>
-		<h3 style="text-align: center;"><a href="javascript:document.getElementById('curators').scrollIntoView();" class="FHULink">Curators</a></h3>
+		<h3 style="text-align: center;"><a href="javascript:document.getElementById('top'     ).scrollIntoView({behaviour:'smooth'});" class="FHULink">Top</a></h3>
+		<h3 style="text-align: center;"><a href="javascript:document.getElementById('managers').scrollIntoView({behaviour:'smooth'});" class="FHULink">Managers</a></h3>
+		<h3 style="text-align: center;"><a href="javascript:document.getElementById('curators').scrollIntoView({behaviour:'smooth'});" class="FHULink">Curators</a></h3>
 		</div>
 		
 		<!--The following ids and classes need to be changed when the JavaScript is reworked. Until then, they should stay as the old names and should not be updated to match new naming guidelines-->

--- a/forumhelpers/index.html
+++ b/forumhelpers/index.html
@@ -27,9 +27,9 @@
 		<br>
 		<!--<h4 style="margin-left: 10px;"><img src="/resources/coder.png" alt="coder" style="width:30px;height:30px;vertical-align:middle"> Indicates that that person has helped code the website.</h4>-->
 		<div class="forumhelpers_navblock">
-		<h3 style="text-align: center;"><a href="javascript:document.getElementById('top'     ).scrollIntoView({behaviour:'smooth'});" class="FHULink">Top</a></h3>
-		<h3 style="text-align: center;"><a href="javascript:document.getElementById('managers').scrollIntoView({behaviour:'smooth'});" class="FHULink">Managers</a></h3>
-		<h3 style="text-align: center;"><a href="javascript:document.getElementById('curators').scrollIntoView({behaviour:'smooth'});" class="FHULink">Curators</a></h3>
+		<h3 style="text-align: center;"><a href="javascript:document.getElementById('top'     ).scrollIntoView({block:'end', behaviour:'smooth'});" class="FHULink">Top</a></h3>
+		<h3 style="text-align: center;"><a href="javascript:document.getElementById('managers').scrollIntoView({block:'end', behaviour:'smooth'});" class="FHULink">Managers</a></h3>
+		<h3 style="text-align: center;"><a href="javascript:document.getElementById('curators').scrollIntoView({block:'end', behaviour:'smooth'});" class="FHULink">Curators</a></h3>
 		</div>
 		
 		<!--The following ids and classes need to be changed when the JavaScript is reworked. Until then, they should stay as the old names and should not be updated to match new naming guidelines-->


### PR DESCRIPTION
I find the `element.scrollIntoView()` function better, but it doesn't make SUCH a big difference, so yeah.
Just an optional minor improvement.