### PR TITLE
Add labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,11 @@
+unreviewed:
+  - ./**/*
+  
+Forum Helpers List:
+  - /forumhelpers/curators.json
+  - /forumhelpers/managers.json
+  
+documentation:
+  - README.md
+  - LICENSE
+  - .github/**/*

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,18 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler
+
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Adds GitHub Actions labeller to this repository. This will automatically label pull requests that are created based on the following guidelines:

Any changes- unreviewed
Changes to managers.json or curators.json- Forum Helpers List
Changes to .github folder or README.md or LICENSE file- documentation

The following need to be tested once this is merged:

- [ ] Sample pull request is marked with unreviewed
- [ ] Sample pull request to curators.json or managers.json is marked with unreviewed and Forum Helpers List
- [ ] Sample pull request to documentation files are marked with unreviewed and documentation.

Resolves #59 

@leahcimto 