### PR TITLE
Add Contributors Page

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,3 +9,4 @@ documentation:
   - README.md
   - LICENSE
   - .github/**/*
+  - contributors/contributors.html

--- a/contributors/contributors.html
+++ b/contributors/contributors.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang=en>
+	<head>
+		<title>Contributors</title>
+		<link rel="shortcut icon" type="image/png" href="../resources/favicon.png">
+		<link rel="stylesheet" type="text/css" href="../resources/stylesheet.css">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<meta name="Description" content="List of people who helped develop this site">
+	</head>
+
+	<body>
+		<embed type="text/html" src="../resources/header.html" style="width:100%; height:70px; margin-bottom:-5px">
+
+		<div class="credits_content">
+			<h1>Contributors</h1>
+			<h2>Thank you to all of the following people who helped make this site possible.</h2>
+			<div class="credits_people" id="credits_people">
+			
+			</div>
+			<h3>Thank you additionally to everyone who submitted biographies for our <a href="https://theforumhelpers.github.io/forumhelpers/" class="FHULink">List of Forum Helpers Page</a>.</h3>
+			<h3>Interested in contibuting? Visit our <a href="https://github.com/theforumhelpers/theforumhelpers.github.io" class="FHULink">GitHub Repository</a>!</h3>
+		</div>
+
+		<embed type="text/html" src="../resources/footer.html" style="width:100%; height:110px; margin-bottom:-5px">
+		
+		<script>
+			var contributors = ["Accio1", "leahcimto", "NilsTheBest", "Nambaseking01", "shefwerld", "ShadowOfTheFuture", "bremea", "awesome-llama", "CodeGuy92", "jeffalo", "LankyBox01", "MTM828", "The64thCucumber"]
+			
+			var i=0
+			var content = ""
+			while (i < contributors.length) {
+				var name = contributors[i]
+				var tempContent = 
+					`<div class="credits_block">
+					<a href="https://github.com/${name}" class="credits_link"><img src="https://github.com/${name}.png?size=100" class="credits_pfp" alt="${name}'s Profile Picture"><br>
+					<p>${name}</p></a>
+				</div>`
+				content = content + tempContent
+				i = i+1
+			}
+			document.getElementById("credits_people").innerHTML = content;
+		</script>
+	</body>
+</html>

--- a/contributors/index.html
+++ b/contributors/index.html
@@ -35,6 +35,12 @@
 					<a href="https://github.com/${name}" class="credits_link"><img src="https://github.com/${name}.png?size=100" class="credits_pfp" alt="${name}'s Profile Picture"><br>
 					<p>${name}</p></a>
 				</div>`
+				if (tempContent.includes("Accio1") == t) {
+					tempContent = `<div class="credits_block">
+					<a href="https://github.com/${name}" class="credits_link"><img src="https://github.com/${name}.png?size=100" class="credits_pfpF" alt="${name}'s Profile Picture"><br>
+					<p>${name}</p></a>
+				</div>`
+				}
 				content = content + tempContent
 				i = i+1
 			}

--- a/contributors/index.html
+++ b/contributors/index.html
@@ -35,12 +35,6 @@
 					<a href="https://github.com/${name}" class="credits_link"><img src="https://github.com/${name}.png?size=100" class="credits_pfp" alt="${name}'s Profile Picture"><br>
 					<p>${name}</p></a>
 				</div>`
-				if (tempContent.includes("Accio1") == t) {
-					tempContent = `<div class="credits_block">
-					<a href="https://github.com/${name}" class="credits_link"><img src="https://github.com/${name}.png?size=100" class="credits_pfpF" alt="${name}'s Profile Picture"><br>
-					<p>${name}</p></a>
-				</div>`
-				}
 				content = content + tempContent
 				i = i+1
 			}

--- a/resources/footer.html
+++ b/resources/footer.html
@@ -1,7 +1,5 @@
 <link rel="stylesheet" type="text/css" href="stylesheet.css">
 <div class="footer_content">
-	<br>
-	<br>
-	<p>This website was made by -Accio- (Accio1 on Github) and NilsTheBest (NilsTheBest on Github) on behalf of the Forum Helpers<br><br><br>
+	<p><a href="https://theforumhelpers.github.io/contributors/" class="FHULink">Contributors</a><br><a href="https://github.com/theforumhelpers/theforumhelpers.github.io" class="FHULink">Github Repository</a><br>
 	Be moist <img src="https://cdn.scratch.mit.edu/scratchr2/static/__4f1f321e080ee4987f163566ecc0dd26__/djangobb_forum/img/smilies/cool.png"></p>
 </div>

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -148,15 +148,51 @@ hr {
 	}
  /*Forum Helpers List*/
 
+/*Credits*/
+.credits_content {
+	color: black;
+	font-size: 20px;
+	width: 100%;
+	text-align: center;
+	margin-top: 0px;
+	font-family: Helvetica, Arial, sans-serif;
+	}
+
+.credits_people {
+	display: flex;
+	padding: 10px 15%;
+	flex-wrap: wrap;
+	justify-content: center;
+}
+
+.credits_block {
+	padding: 20px;
+	width: 250px;
+	box-sizing: border-box;
+}
+
+.credits_pfp {
+	border-radius: 10px;
+	width: 100px;
+}
+
+.credits_link {
+	color: black;
+	text-decoration: none;
+	font-weight: bold;
+}
+/*Credits*/
+
 /*Footer*/
 .footer_content {
 	background: #31ACBA;
 	color: white;
 	font-size: 20px;
 	width: 100%;
+	padding: 10px;
 	height: 110px;
+	box-sizing: border-box;
 	text-align: center;
-	line-height: 10px;
 	font-family: Arial, sans-serif;
 	}
 


### PR DESCRIPTION
Resolves #36 

Change Log:
- Add contributors page sorted in a grid fashion. It is sorted from most to least commits. For the people who contributed outside of commits (eg. issue creation), it is sorted alphabetically. It is generated using JavaScript, so if someone else contributes, their GitHub username can be added to the contributors array and they will be added to the page.
- Added a link to the contributors page and GitHub repository to the footer.
- Made labeler label PRs involving the contributors page as "documentation".

Next Steps: 
- Add more information to the page (eg. what kind of contributions did the person make?)
- Add badges to the list of Forum Helpers page indicating if someone has contributed to the site

@leahcimto 