### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# macOS (OSX)
+.DS_Store


### PR DESCRIPTION
Creates a gitignore file. This helps for users that use Mac OS to contribute to this repo since when editing a file the system often commits a .DS_Store file (don't ask why).

So yes this is user-specific since it only affects Mac OS but I do hope this gets merged because it is getting kinda annoying deleting these files by hand every time I commit.

(also I've never done this before I just searched it up on google)