### PR TITLE
Update Forum Helpers Page JavaScript

### DIFF
--- a/forumhelpers/FHP.js
+++ b/forumhelpers/FHP.js
@@ -1,53 +1,60 @@
-var man_addition=""
-var man_pull = new XMLHttpRequest()
+function getData(dataSet) {
+	var grabDelay = 0
+	fetch("https://theforumhelpers.github.io/forumhelpers/"+dataSet+".json")
+		.then(response => response.json())
+		.then(data => {
+			document.getElementById(dataSet+"Number").innerHTML = data.length;
+			for (j = 0; j < data.length; j++) {
+				var name = data[j].name;
+				var id = data[j].id;
+				var bio = data[j].bio;
+				var section = document.getElementById(dataSet+"List").innerHTML;
+				var addition = `
+				<div class="profileContainer" id="${name}">
+					<h4 class="profileName"><a href="https://scratch.mit.edu/users/${name}/">${name}</a><span id="${name}Posts"></span></h4>
+					<div class="profileInner">
+						<a href="https://scratch.mit.edu/users/${name}/"><img src="https://cdn2.scratch.mit.edu/get_image/user/${id}_60x60.png" class="profilePicture" id="${name}pfp" loading="lazy" alt="${name}'s Profile Picture"></a>
+						<p class="profileBio">${bio}</p>
+					</div>
+					<p class="FullOcular" id="${name}Ocular" style="border: 5px solid black; border-radius: 10px; padding: 5px; margin-right:20%; width: fit-content" title="Ocular Status"><span class="ocularStatus" id="${name}Status">Loading Status...</span></p>
+				</div>
+				<hr>`;
+				document.getElementById(dataSet+"List").innerHTML = section + addition;
+				if (j == data.length-1 && dataSet != "curators") {
+					getData("curators");
+				}
+				else if (j == data.length-1) {
+					document.getElementById("totalNumber").innerHTML = parseInt(document.getElementById("managersNumber").innerHTML) + parseInt(document.getElementById("curatorsNumber").innerHTML);
+				}
+				grabDelay = grabDelay + 250;
+				setTimeout(getOcular, grabDelay, name);
+				//setTimeout(getCount, grabDelay, name);
+			}
+		});
 
-man_pull.open("GET", "https://theforumhelpers.github.io/forumhelpers/managers.json");
-man_pull.send();
-man_pull.onreadystatechange = function() {
-	if (man_pull.readyState === 4 && man_pull.status === 200) {
-   		man_pulldone = JSON.parse(man_pull.responseText);
-		man_legnth = Object.keys(man_pulldone).length
-		for(var man_key in man_pulldone){
-    			var man_keyjson = man_pulldone[man_key];
-			var man_username = man_keyjson.name
-			var man_userID = man_keyjson.id
-			var man_bio = man_keyjson.bio
-			var man_add=
-			`<div class="forumhelpers_blocks"><h4 class="forumhelpers_name"><a href="https://scratch.mit.edu/users/${man_username}/" class="FHULink">${man_username}</a></h4>
-			<a href="https://scratch.mit.edu/users/${man_username}/"><img src="https://uploads.scratch.mit.edu/get_image/user/${man_userID}_60x60.png" class="forumhelpers_pfp" loading="lazy" alt="${man_username}'s Profile Picture"></a>
-			<p class="forumhelpers_bio">${man_bio}</p>
-			<br></div>
-			<hr>`
-
-				man_addition= man_addition+man_add
-				document.getElementById("FHPMan_Lists").innerHTML=man_addition;
-   		}
-	}
 }
 
-var cur_addition=""
-var cur_pull = new XMLHttpRequest()
+function getOcular(name) {
+	fetch("https://my-ocular.jeffalo.net/api/user/"+name)
+		.then(response => response.json())
+		.then(data => {
+			var status = data.status;
+			status ??= "none";
+			if (status != "none") {
+				document.getElementById(name+"Status").innerText = status;
+				document.getElementById(name+"Ocular").style.borderColor = data.color;
+			}
+			else {
+				document.getElementById(name+"Ocular").style.display = "none";
+			}
+		});
+}
 
-cur_pull.open("GET", "https://theforumhelpers.github.io/forumhelpers/curators.json");
-cur_pull.send();
-cur_pull.onreadystatechange = function() {
-  	if (cur_pull.readyState === 4 && cur_pull.status === 200) {
-   		cur_pulldone = JSON.parse(cur_pull.responseText);
-		cur_legnth = Object.keys(cur_pulldone).length
-		for(var cur_key in cur_pulldone){
-    			var cur_keyjson = cur_pulldone[cur_key];
-			var cur_username = cur_keyjson.name
-			var cur_userID = cur_keyjson.id
-			var cur_bio = cur_keyjson.bio
-			var cur_add=
-			`<div class="forumhelpers_blocks"><h4 class="forumhelpers_name"><a href="https://scratch.mit.edu/users/${cur_username}/" class="FHULink">${cur_username}</a></h4>
-			<a href="https://scratch.mit.edu/users/${cur_username}/"><img src="https://uploads.scratch.mit.edu/get_image/user/${cur_userID}_60x60.png" class="forumhelpers_pfp" loading="lazy" alt="${cur_username}'s Profile Picture"></a>
-			<p class="forumhelpers_bio">${cur_bio}</p>
-			<br></div>
-			<hr>`
-
-			cur_addition= cur_addition+cur_add
-			document.getElementById("FHPCur_Lists").innerHTML=cur_addition;
-		}
-	}
+function getCount(name) {
+	fetch("https://scratchdb.lefty.one/v2/forum/user/info/"+name)
+		.then(response => response.json())
+		.then(data => {
+			var posts = data.counts.total.count;
+			document.getElementById(name+"Posts").innerText = " - "+posts+" Posts";
+		});
 }

--- a/forumhelpers/FHP.js
+++ b/forumhelpers/FHP.js
@@ -16,7 +16,7 @@ function getData(dataSet) {
 						<a href="https://scratch.mit.edu/users/${name}/"><img src="https://cdn2.scratch.mit.edu/get_image/user/${id}_60x60.png" class="profilePicture" id="${name}pfp" loading="lazy" alt="${name}'s Profile Picture"></a>
 						<p class="profileBio">${bio}</p>
 					</div>
-					<p class="FullOcular" id="${name}Ocular" style="border: 5px solid black; border-radius: 10px; padding: 5px; margin-right:20%; width: fit-content" title="Ocular Status"><span class="ocularStatus" id="${name}Status">Loading Status...</span></p>
+					<p class="ocularStatusBox" id="${name}Ocular" title="Ocular Status"><span class="ocularStatus" id="${name}Status">Loading Status...</span></p>
 				</div>
 				<hr>`;
 				document.getElementById(dataSet+"List").innerHTML = section + addition;

--- a/forumhelpers/FHP.js
+++ b/forumhelpers/FHP.js
@@ -26,9 +26,9 @@ function getData(dataSet) {
 				else if (j == data.length-1) {
 					document.getElementById("totalNumber").innerHTML = parseInt(document.getElementById("managersNumber").innerHTML) + parseInt(document.getElementById("curatorsNumber").innerHTML);
 				}
-				grabDelay = grabDelay + 250;
-				setTimeout(getOcular, grabDelay, name);
-				//setTimeout(getCount, grabDelay, name);
+				grabDelay = grabDelay + 500;
+				getOcular(name);
+				setTimeout(getCount, grabDelay, name);
 			}
 		});
 
@@ -51,7 +51,7 @@ function getOcular(name) {
 }
 
 function getCount(name) {
-	fetch("https://scratchdb.lefty.one/v2/forum/user/info/"+name)
+	fetch("https://scratchdb.lefty.one/v3/forum/user/info/"+name)
 		.then(response => response.json())
 		.then(data => {
 			var posts = data.counts.total.count;

--- a/forumhelpers/index.html
+++ b/forumhelpers/index.html
@@ -8,7 +8,7 @@
 		<meta name="Description" content="The list of all the Forum Helpers who are in the Scratch Forum Helpers studio, as well as their biographies.">
 	</head>
 
-	<body>
+	<body onload="getData('managers')">
 	<embed type="text/html" src="../resources/header.html" style="width:100%; height:70px; margin-bottom:-5px">
 
 
@@ -19,14 +19,15 @@
 		<h1>Please enable JavaScript to display this page</h1>
 		<h3>Javascript is required to display the list of Forum Helpers</h3>
 	</noscript>
-		
+
 
 	<div class="forumhelpers_content">
 		<br>
 		<h1 class="forumhelpers_header">Current Forum Helpers</h1>
 		<br>
-		<h3 class="forumhelpers_header">Below is a list of current Forum Helpers, along with their profile picture and biography.</h3>
+		<h3 class="forumhelpers_header">Below is a list of current Forum Helpers, along with their profile picture, biography, and <a href="https://ocular.jeffalo.net/">Ocular Status</a>.</h3>
 		<br>
+		<p class="forumhelpers_header">There are currently <span id="managersNumber"></span> Managers and <span id="curatorsNumber"></span> Curators in our studio, for a total of <span id="totalNumber"></span> members.</p>
 		<!--<h4 style="margin-left: 10px;"><img src="/resources/coder.png" alt="coder" style="width:30px;height:30px;vertical-align:middle"> Indicates that that person has helped code the website.</h4>-->
 		<div class="forumhelpers_navblock">
 			<h3><a href="#top" class="FHULink">Top</a></h3>
@@ -34,11 +35,10 @@
 			<h3><a href="#curators" class="FHULink">Curators</a></h3>
 		</div>
 
-			<!--The following ids and classes need to be changed when the JavaScript is reworked. Until then, they should stay as the old names and should not be updated to match new naming guidelines-->
-			<h1 class="forumhelpers_subheaders" id="managers">Managers</h1>
-			<div id="FHPMan_Lists"><h3>Loading...</h3></div>
-			<h1 class="forumhelpers_subheaders" id="curators">Curators</h1>
-			<div id="FHPCur_Lists"><h3>Loading...</h3></div>
+		<h1 class="forumhelpers_subheaders" id="managers">Managers</h1>
+		<div id="managersList"></div>
+		<h1 class="forumhelpers_subheaders" id="curators">Curators</h1>
+		<div id="curatorsList"></div>
 	</div>
 
 

--- a/forumhelpers/managers.json
+++ b/forumhelpers/managers.json
@@ -189,7 +189,7 @@
     },
 
     {
-	"name": "ShadowOfTheFuture",
+	"name": "-ShadowOfTheFuture-",
         "id": "24605721",
         "bio": "Hi! I'm a semi-active Scratcher who pops up on the forums every now and then, though not nearly as much as I used to.",
         "helped_code": false
@@ -334,7 +334,7 @@
         "bio": "Hi, I'm Bluebatstar. I make games on Scratch, and I like to think they're high quality, and are (more importantly) fun to play. I go in QaS too. Oh, and outside of that I like Walking, Nintendo, Golf, Paddleboarding, and Game Soundtracks. (Interesting selection, I know.) Oh, and I love Scolipede.",
         "helped_code": false
     },
-	
+
     {
         "name": "jeffalo",
         "id": 34018398,

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -150,6 +150,14 @@ hr {
 	margin: 0px 20px 10px 0px;
 	text-align: left;
 	}
+
+.ocularStatusBox {
+	border: 5px solid black;
+	border-radius: 10px;
+	padding: 5px;
+	margin-right:20%;
+	width: fit-content;
+}
  /*Forum Helpers List*/
 
 /*Credits*/

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -6,6 +6,24 @@ body {
 	background: #B7E4E2;
 	}
 
+a {
+	color: inherit;
+	background-color: inherit;
+	text-decoration: underline;
+}
+
+a:visited:not(.nav_button):visited  {
+	color: inherit;
+	background-color: inherit;
+	text-decoration: underline;
+	}
+
+a:hover:not(.nav_button):hover {
+	color: blue;
+	background-color: inherit;
+	text-decoration: underline;
+	}
+
 /*navbar*/
 .nav_content {
 	background: #31ACBA;
@@ -47,26 +65,6 @@ body {
 	}
 
 /*navbar*/
-
-/* Page Links*/
-.FHULink:link {
-	color: inherit;
-	background-color: inherit;
-	text-decoration: underline;
-	}
-
-.FHULink:visited {
-	color: inherit;
-	background-color: inherit;
-	text-decoration: underline;
-	}
-
-.FHULink:hover {
-	color: blue;
-	background-color: inherit;
-	text-decoration: underline;
-	}
-/*Page Links*/
 
 /*Main Page*/
 .home_content {
@@ -116,23 +114,31 @@ hr {
 	}
 
 .forumhelpers_subheaders{
+	width: fit-content;
 	margin-left: 20px;
-	margin-right: 20px;
 	background: #31ACBA;
 	padding: 10px;
 	border-radius: 10px;
 	}
 
-.forumhelpers_blocks {
+.profileContainer {
 	min-height: 130px;
 	margin-left: 20px;
 	}
 
-.forumhelpers_name {
+.profileName {
 	font-family: Arial, sans-serif;
 	}
 
-.forumhelpers_pfp {
+.profileInner {
+	display: grid;
+	grid-template-columns: auto calc(100vw - 30vw);
+	grid-template-rows: minmax(min-content, max-content);
+	justify-content: start;
+	align-content: start;
+}
+
+.profilePicture {
 	float: left;
   	border-radius: 10px;
 	margin-right: 10px;
@@ -140,11 +146,9 @@ hr {
  	width: 60px;
 	}
 
-.forumhelpers_bio {
-	margin-left: 20px;
-	margin-right: 20%;
-	margin-bottom: 0px;
-	text-align: justify;
+.profileBio {
+	margin: 0px 20px 10px 0px;
+	text-align: left;
 	}
  /*Forum Helpers List*/
 


### PR DESCRIPTION
### Resolves:

This resolves #65 and most of #31

### Changes:
-Switch to fetch() instead of XMLRequests
-Add ocular statuses to the list of Forum Helpers page.
-Add the ability to get post counts from ScratchDB, but that seems to be down right now, so it is currently disabled.
-Display the number of curators, managers, and total members on the list of Forum Helpers page.

### Local Tests:

Tested Locally

@jeffalo @leahcimto 
