### PR TITLE
Fix 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,18 +2,19 @@
 <html lang=en>
 	<head>
 		<title>404 - Page Not Found</title>
-        <link rel="shortcut icon" type="image/png" href="resources/favicon.png">
+		<base href="https://theforumhelpers.github.io"> <!--If making local changes, change the base tag to point to how your filesystem is set up-->
+		<link rel="shortcut icon" type="image/png" href="resources/favicon.png">
 		<link rel="stylesheet" type="text/css" href="resources/stylesheet.css">
 	</head>
 	<body>
 		<embed type="text/html" src="resources/header.html" style="width:100%; height:70px; margin-bottom:-5px">
-        <div class="lost_title">
-           <p>404 – Page Not Found</p>
-        </div>
-        <br>
-        <div class="lost_content">
-            <p>Hmmm... looks like you're lost. But don't worry! The magic taco can help you find your way back to the homepage. Just click on it!</p>
-            <a href="index.html" class="FHULink" alt="Magic Taco" title="Click me!"><img src="resources/Taco-wizard.svg"></a>
-        </div>
+		<div class="lost_title">
+			<p>404 – Page Not Found</p>
+		</div>
+		<br>
+		<div class="lost_content">
+			<p>Hmmm... looks like you're lost. But don't worry! The magic taco can help you find your way back to the homepage. Just click on it!</p>
+			<a href="/" class="FHULink" alt="Magic Taco" title="Click me!"><img src="resources/Taco-wizard.svg"></a>
+		</div>
 	</body>
 </html>


### PR DESCRIPTION
Use a `<base>` element to ensure that all relative links point to the correct files.

### Resolves:

Resolves #141 

### Changes:

This PR adds a `<base>` element to the 404 page to ensure that all relative links point to the correct files. This means that anyone locally editing this page will have to temporarily change the <base> element to how their filesystem is set up so that their changes are displayed on the page.

### Local Tests:

Tested on a fork of this repo deployed to GH pages.
Unknown URLS ending in nothing and ending in a slash both worked.

@leahcimto @gosoccerboy5
