### PR TITLE
Make the footer a bit better

### DIFF
--- a/resources/imports.js
+++ b/resources/imports.js
@@ -17,13 +17,15 @@ function reference(link) {
 
 	const footerContent = `
 	<div class="footer_content">
-		<p>
+		<div class = "FHULinkDiv">
 			<a href="${link}contributors/" class="FHULink" target="_parent">Contributors</a>
-			<br>
+		</div>
+		<div class = "FHULinkDiv">
 			<a href="https://github.com/theforumhelpers/theforumhelpers.github.io" class="FHULink" target="_parent">Github Repository</a>
-			<br>
+		</div>
+		<div class = "FHULinkDiv">
 			Be moist <img src="https://cdn.scratch.mit.edu/scratchr2/static/__4f1f321e080ee4987f163566ecc0dd26__/djangobb_forum/img/smilies/cool.png">
-		</p>
+		</div>
 	</div>`
 	document.getElementById("footer").innerHTML = footerContent;
 }

--- a/resources/imports.js
+++ b/resources/imports.js
@@ -17,15 +17,11 @@ function reference(link) {
 
 	const footerContent = `
 	<div class="footer_content">
-		<div class = "FHULinkDiv">
 			<a href="${link}contributors/" class="FHULink" target="_parent">Contributors</a>
-		</div>
-		<div class = "FHULinkDiv">
+			<br>
 			<a href="https://github.com/theforumhelpers/theforumhelpers.github.io" class="FHULink" target="_parent">Github Repository</a>
-		</div>
-		<div class = "FHULinkDiv">
+			<br>
 			Be moist <img src="https://cdn.scratch.mit.edu/scratchr2/static/__4f1f321e080ee4987f163566ecc0dd26__/djangobb_forum/img/smilies/cool.png">
-		</div>
 	</div>`
 	document.getElementById("footer").innerHTML = footerContent;
 }

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -292,12 +292,8 @@ hr {
 	box-sizing: border-box;
 	text-align: center;
 	font-family: Arial, sans-serif;
+	line-height: 30px;
 	height: auto;
-	}
-.FHULinkDiv {
-	padding-top: 3px;
-	padding-bottom: 3px;
-	/* allows for customizable padding, without weird margins */
 }
 
 /*Footer*/

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -292,9 +292,12 @@ hr {
 	box-sizing: border-box;
 	text-align: center;
 	font-family: Arial, sans-serif;
+	height: auto;
 	}
 .FHULinkDiv {
-	padding-top: 5px;
+	padding-top: 3px;
+	padding-bottom: 3px;
+	/* allows for customizable padding, without weird margins */
 }
 
 /*Footer*/

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -293,5 +293,8 @@ hr {
 	text-align: center;
 	font-family: Arial, sans-serif;
 	}
+.FHULinkDiv {
+	padding-top: 5px;
+}
 
 /*Footer*/


### PR DESCRIPTION
### Resolves:

_What Github issue does this resolve (please include link)? Do NOT create a Pull Request for a major issue that you have not been assigned to unless you are a part of the editors team for this repo._
This will fix #89 (footer text should be more spaced out).
It also resolves an issue on my machine where there's footer overflow that looks bad.
Screenshot of current TFH build:
<img width="731" alt="Screen Shot 2021-05-08 at 9 58 08 PM" src="https://user-images.githubusercontent.com/82768218/117559149-917db280-b048-11eb-837e-9799e9d47d23.png">


### Changes:

_Describe what this Pull Request does. Be sure to include a brief description of the issue the Pull Requests solves too._
This just changes a CSS property (thanks -Accio-), and removes the `<p>` tag from the footer.
With those changes, the footer is perfectly spaced and looks fine.

### Local Tests:

_Did you test this locally? Example: I tested this via GitHub Desktop and everything looked fine._
Tested locally with Github Desktop, looks great. Also, used Firefox's responsive design mode to simulate mobile devices. Still looks great.
<img width="503" alt="Screen Shot 2021-05-09 at 4 15 43 PM" src="https://user-images.githubusercontent.com/82768218/117587115-f0433a80-b0e1-11eb-93e3-d8e3c6e4b844.png">

