### PR TITLE
Update 404 page to have header

### DIFF
--- a/404.html
+++ b/404.html
@@ -7,7 +7,7 @@
 		<link rel="stylesheet" type="text/css" href="resources/stylesheet.css">
 	</head>
 	<body>
-		<embed type="text/html" src="resources/header.html" style="width:100%; height:70px; margin-bottom:-5px">
+		<header id="header"></header>
 		<div class="lost_title">
 			<p>404 – Page Not Found</p>
 		</div>
@@ -16,5 +16,6 @@
 			<p>Hmmm... looks like you're lost. But don't worry! The magic taco can help you find your way back to the homepage. Just click on it!</p>
 			<a href="/" class="FHULink" alt="Magic Taco" title="Click me!"><img src="resources/Taco-wizard.svg"></a>
 		</div>
+		<script src="resources/imports.js" onload="reference('./');"></script>
 	</body>
 </html>


### PR DESCRIPTION
when we switched to using js for the header, the 404 page was not updated

### Resolves:

_What Github issue does this resolve (please include link)? Do NOT create a Pull Request for a major issue that you have not been assigned to unless you are a part of the editors team for this repo._
fixes #166

### Changes:

_Describe what this Pull Request does. Be sure to include a brief description of the issue the Pull Requests solves too._
This adds the missing <script> tag that was necessary and also removes the dead \<embed> tag for the header

### Local Tests:

_Did you test this locally? Example: I tested this via GitHub Desktop and everything looked fine._
Tested locally looks fine, I would appreciate if you could check also

current official build:
<img width="1440" alt="Screen Shot 2021-05-12 at 2 58 53 PM" src="https://user-images.githubusercontent.com/82768218/118036771-9b4a3300-b332-11eb-9fd2-cdcbbc6a2fa8.png">
This branch on my fork:
<img width="1439" alt="Screen Shot 2021-05-12 at 2 58 45 PM" src="https://user-images.githubusercontent.com/82768218/118036799-a309d780-b332-11eb-9894-a6055836f0ac.png">
