### PR TITLE
Add Google Analytics and Privacy Policy

### DIFF
--- a/contributors/index.html
+++ b/contributors/index.html
@@ -21,6 +21,7 @@
 			<h2>Thank you to the following services and their contributors that help make this site possible.</h2>
 			<p><a href="https://ocular.jeffalo.net/" class="FHULink">Ocular by Jeffalo</a> - Used to get Ocular Statuses for the List of Forum Helpers Page.</p>
 			<p><a href="https://scratchdb.lefty.one/" class="FHULink">ScratchDB by DatOneLefty</a> - Used to get post counts for the List of Forum Helpers Page.</p>
+			<p><a href="https://analytics.google.com/analytics/web/" class="FHULink">Google Analytics</a> - Used to get statistics about the usage of the site.</p>
 
 			<br>
 			<h3>Thank you additionally to everyone who submitted biographies for our <a href="https://theforumhelpers.github.io/forumhelpers/" class="FHULink">List of Forum Helpers Page</a>.</h3>

--- a/contributors/index.html
+++ b/contributors/index.html
@@ -27,6 +27,8 @@
 			<h3>Interested in contributing? Visit our <a href="https://github.com/theforumhelpers/theforumhelpers.github.io" class="FHULink">GitHub Repository</a>!</h3>
 		</div>
 
+		<div class="privacyWarning" id="privacyWarning"></div>
+
 		<footer id="footer"></footer>
 		<script src="../resources/imports.js" onload='reference("../")'></script>
 		<script>

--- a/forumhelpers/index.html
+++ b/forumhelpers/index.html
@@ -6,8 +6,18 @@
 		<link rel="stylesheet" type="text/css" href="../resources/stylesheet.css">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="Description" content="The list of all the Forum Helpers who are in the Scratch Forum Helpers studio, as well as their biographies.">
+
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-FGN5P806VX"></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag(){dataLayer.push(arguments);}
+			gtag('js', new Date());
+
+			gtag('config', 'G-FGN5P806VX');
+		</script>
 	</head>
-	
+
 	<body onload="getData('managers')">
 	<header id="header"></header>
 
@@ -39,6 +49,8 @@
 		<h1 class="forumhelpers_subheaders" id="curators">Curators</h1>
 		<div id="curatorsList"></div>
 	</div>
+
+	<div class="privacyWarning" id="privacyWarning"></div>
 
 	<footer id="footer"></footer>
 	<script src="../resources/imports.js" onload='reference("../")'></script>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,16 @@
 		<link rel="stylesheet" type="text/css" href="resources/stylesheet.css">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="Description" content="The official website for the Scratch Forum Helpers. This contains information about who we are and what we do.">
+
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-FGN5P806VX"></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag(){dataLayer.push(arguments);}
+			gtag('js', new Date());
+
+			gtag('config', 'G-FGN5P806VX');
+		</script>
 	</head>
 
 	<body>
@@ -24,6 +34,8 @@
 			<p class="home_answers">Once you apply, a manager of the studio will check out your application and see if you meet the requirements. If you don't, you will be rejected in which case you can re-apply in a week. If your application contains all the required components, a manager will post the link in the Forum Helpers Special Actions studio and it will enter a one week "Application Pending" window. During this time, your application will be discussed by current Forum Helpers. If no one objects to you joining during this time, then your application will be accepted and you will be invited to the studio. If one or more managers object to you joining, then your application will be declined and you will be given some feedback on how to improve. If your application is declined, please wait at least one week before reapplying.</p>
 			<br>
 		</div>
+
+		<div class="privacyWarning" id="privacyWarning"></div>
 
 		<footer id="footer"></footer>
 		<script src="resources/imports.js" onload='reference("")'></script>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang=en>
+	<head>
+		<title>The Forum Helpers</title>
+		<link rel="shortcut icon" type="image/png" href="../resources/favicon.png">
+		<link rel="stylesheet" type="text/css" href="../resources/stylesheet.css">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<meta name="Description" content="The official website for the Scratch Forum Helpers. This contains information about who we are and what we do.">
+
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-FGN5P806VX"></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag(){dataLayer.push(arguments);}
+			gtag('js', new Date());
+
+			gtag('config', 'G-FGN5P806VX');
+		</script>
+	</head>
+
+	<body>
+		<header id="header"></header>
+
+		<div class="privacy_content">
+			<h1 style="text-align: center;">Privacy</h1>
+			<h3>Google Analytics</h3>
+			<ul>
+				<li>In order to gain statistics about the number of people who are using our site, and how people interact with the site, we use Google Analytics to track page views and interactions.</li>
+				<li>Google Analytics tracks your website usage by placing cookies on your computer and by continuing to use this site, you agree to the use of these cookies.</li>
+				<li>We recommend that you check out <a href="https://policies.google.com/technologies/partner-sites">How Google uses data when you use our partners' sites or apps</a> for additional information about Google Analytics.</li>
+				<li>Examples of data that Google Analytics may collect include: IP Address, Operating System, the amount of time that you spend on each page, and what you click while on the page.</li>
+				<li>This data is not shared or sold with anybody besides site developers, who use it to improve the site based on usage statistics.</li>
+				<li>If you do not agree to the use of Google Analytics, please discontinue your use of this site. Alternatively, consider installing the <a href="https://support.google.com/analytics/answer/181881?hl=en-GB">Google Analytics opt-out browser add-on</a>.</li>
+			</ul>
+
+			<h3>Other</h3>
+			<ul>
+				<li>Aside from Google Analytics, this site also stores two cookies on your computer which save whether or not you have agreed to the use of Google Analytics, and the date that you agreed.</li>
+				<li>This cookie expires each month, so you will have to re-accept the use of Google Analytics when you visit our site in a month that you have not yet accepted.</li>
+				<li>Questions? Feel free to contact us by opening a discussion on our GitHub repository.</li>
+			</ul>
+		</div>
+
+		<footer id="footer"></footer>
+		<script src="../resources/imports.js" onload='reference("../")'></script>
+	</body>
+</html>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -37,7 +37,7 @@
 			<ul>
 				<li>Aside from Google Analytics, this site also stores two cookies on your computer which save whether or not you have agreed to the use of Google Analytics, and the date that you agreed.</li><br>
 				<li>This cookie expires each month, so you will have to re-accept the use of Google Analytics when you visit our site in a month that you have not yet accepted.</li><br>
-				<li>Questions? Feel free to contact us by <a href="https://github.com/theforumhelpers/theforumhelpers.github.io/discussions">opening a discussion</a> on our GitHub repository.</li>
+				<li>Questions? Feel free to contact us by <a href="https://github.com/theforumhelpers/theforumhelpers.github.io/discussions/new?category=q-a">opening a discussion</a> on our GitHub repository.</li>
 			</ul>
 		</div>
 

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -25,19 +25,19 @@
 			<h1 style="text-align: center;">Privacy</h1>
 			<h3>Google Analytics</h3>
 			<ul>
-				<li>In order to gain statistics about the number of people who are using our site, and how people interact with the site, we use Google Analytics to track page views and interactions.</li>
-				<li>Google Analytics tracks your website usage by placing cookies on your computer and by continuing to use this site, you agree to the use of these cookies.</li>
-				<li>We recommend that you check out <a href="https://policies.google.com/technologies/partner-sites">How Google uses data when you use our partners' sites or apps</a> for additional information about Google Analytics.</li>
-				<li>Examples of data that Google Analytics may collect include: IP Address, Operating System, the amount of time that you spend on each page, and what you click while on the page.</li>
-				<li>This data is not shared or sold with anybody besides site developers, who use it to improve the site based on usage statistics.</li>
+				<li>In order to gain statistics about the number of people who are using our site, and how people interact with the site, we use Google Analytics to track page views and interactions.</li><br>
+				<li>Google Analytics tracks your website usage by placing cookies on your computer and by continuing to use this site, you agree to the use of these cookies.</li><br>
+				<li>We recommend that you check out <a href="https://policies.google.com/technologies/partner-sites">How Google uses data when you use our partners' sites or apps</a> for additional information about Google Analytics.</li><br>
+				<li>Examples of data that Google Analytics may collect include: IP Address, Operating System, the amount of time that you spend on each page, and what you click while on the page.</li><br>
+				<li>This data is not shared or sold with anybody besides site developers, who use it to improve the site based on usage statistics.</li><br>
 				<li>If you do not agree to the use of Google Analytics, please discontinue your use of this site. Alternatively, consider installing the <a href="https://support.google.com/analytics/answer/181881?hl=en-GB">Google Analytics opt-out browser add-on</a>.</li>
 			</ul>
 
 			<h3>Other</h3>
 			<ul>
-				<li>Aside from Google Analytics, this site also stores two cookies on your computer which save whether or not you have agreed to the use of Google Analytics, and the date that you agreed.</li>
-				<li>This cookie expires each month, so you will have to re-accept the use of Google Analytics when you visit our site in a month that you have not yet accepted.</li>
-				<li>Questions? Feel free to contact us by opening a discussion on our GitHub repository.</li>
+				<li>Aside from Google Analytics, this site also stores two cookies on your computer which save whether or not you have agreed to the use of Google Analytics, and the date that you agreed.</li><br>
+				<li>This cookie expires each month, so you will have to re-accept the use of Google Analytics when you visit our site in a month that you have not yet accepted.</li><br>
+				<li>Questions? Feel free to contact us by <a href="https://github.com/theforumhelpers/theforumhelpers.github.io/discussions">opening a discussion</a> on our GitHub repository.</li>
 			</ul>
 		</div>
 

--- a/resources/imports.js
+++ b/resources/imports.js
@@ -17,11 +17,36 @@ function reference(link) {
 
 	const footerContent = `
 	<div class="footer_content">
-			<a href="${link}contributors/" class="FHULink" target="_parent">Contributors</a>
-			<br>
-			<a href="https://github.com/theforumhelpers/theforumhelpers.github.io" class="FHULink" target="_parent">Github Repository</a>
-			<br>
-			Be moist <img src="https://cdn.scratch.mit.edu/scratchr2/static/__4f1f321e080ee4987f163566ecc0dd26__/djangobb_forum/img/smilies/cool.png">
+			<p><a href="${link}contributors/" class="FHULink" target="_parent">Contributors</a></p>
+			<p><a href="https://github.com/theforumhelpers/theforumhelpers.github.io" class="FHULink" target="_parent">Github Repository</a></p>
+			<p>Be moist <img src="https://cdn.scratch.mit.edu/scratchr2/static/__4f1f321e080ee4987f163566ecc0dd26__/djangobb_forum/img/smilies/cool.png"></p>
+			<p style="font-size: 12px;">This site uses Google Analytics. Check out our <a href="${link}privacy/" class="FHULink" target="_parent">Privacy Policy</a> for more information</p>
 	</div>`
 	document.getElementById("footer").innerHTML = footerContent;
+
+	const privacyContent = `
+	<p style="margin:0px;">This site uses Google Analytics.<br>Check out our <a href="${link}privacy/" class="FHULink" target="_parent">Privacy Policy</a> for more information.</p><br>
+	<button class="privacyButton" onclick="acceptPrivacy()">Okay</button> <button class="privacyButton" onclick="denyPrivacy()">Leave Site</button>`
+	var currentDate = new Date();
+	var currentMonth = currentDate.getMonth();
+	//var currentDay = currentDate.getDate();
+	var storedDate = new Date(localStorage.getItem("FHacceptedDate"));
+	var storedMonth = storedDate.getMonth() ?? 100;
+	//var storedDay = storedDate.getDate() ?? 100;
+	if (currentMonth != storedMonth /*|| storedDay+7 < currentDay*/) {
+		document.getElementById("privacyWarning").innerHTML = privacyContent;
+	}
+}
+
+function acceptPrivacy() {
+	var setDate = new Date();
+	localStorage.setItem("FHacceptedAnalytics", "true");
+	localStorage.setItem("FHacceptedDate", setDate);
+	document.getElementById("privacyWarning").style.display = "none";
+}
+
+function denyPrivacy() {
+	localStorage.removeItem("FHacceptedAnalytics");
+	localStorage.removeItem("FHacceptedDate");
+	window.location.href = "https://scratch.mit.edu/studios/3688309/";
 }

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -156,7 +156,6 @@ header {
 	margin-left: 10%;
 	margin-right: 10%;
 	}
-
 /*Main Page*/
 
 /*Forum Helpers List*/
@@ -271,6 +270,43 @@ hr {
 }
 /*Credits*/
 
+/*Privacy*/
+.privacy_content {
+	color: black;
+	font-size: 20px;
+	width: 100%;
+	margin-top: 0px;
+	font-family: Arial, sans-serif;
+	box-sizing: border-box;
+	padding: 20px;
+	}
+
+.privacyWarning {
+	font-family: Arial, sans-serif;
+	position: fixed;
+	width: 100%;
+	padding: 10px;
+	bottom: 0px;
+	background-color: #fff959;
+	text-align: center;
+}
+
+.privacyWarning:empty {
+	display: none;
+}
+
+.privacyButton {
+	border: 3px solid black;
+	border-radius: 10px;
+	padding: 10px;
+	width: 100px;
+}
+
+.privacyButton:hover {
+	background-color: lightgrey;
+}
+/*Privacy*/
+
 /*404 (had to use lost since css won't use numbers at the start of class names*/
 .lost_title {
 	color:black;
@@ -298,7 +334,7 @@ hr {
 	box-sizing: border-box;
 	text-align: center;
 	font-family: Arial, sans-serif;
-	line-height: 30px;
+	line-height: 10px;
 	height: auto;
 }
 

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -279,7 +279,7 @@ hr {
 	font-family: Arial, sans-serif;
 	box-sizing: border-box;
 	padding: 20px;
-	}
+}
 
 .privacyWarning {
 	font-family: Arial, sans-serif;


### PR DESCRIPTION
### Resolves:

Does not resolve a specific issue. This was discussed by @Accio1 @leahcimto and @MakeTheBrainHappy as a way to improve the site.

### Changes:

-Adds Google Analytics to track site interactions.
-Adds a privacy warning banner on the bottom of the page when you visit for the first time in a new month.
-Adds a privacy policy and a link to it in the footer.

### Local Tests:

Tested locally. Note: As far as I know, Google Analytics does not track local usage statistics, so I won't know if the code works until it is on the actual site.

The banner informing about Google Analytics should only show up once. Once you press "Okay" it will not show up again until next month. To test that this works, you can clear local data using the Chrome Inspect Element.

Reviewers: Also feel free to suggest wording changes to the Privacy Policy.

@leahcimto
