### PR TITLE
Update Google Analytics

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,6 +5,16 @@
 		<base href="https://theforumhelpers.github.io"> <!--If making local changes, change the base tag to point to how your filesystem is set up-->
 		<link rel="shortcut icon" type="image/png" href="resources/favicon.png">
 		<link rel="stylesheet" type="text/css" href="resources/stylesheet.css">
+		
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-197061964-2"></script>
+		<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag(){dataLayer.push(arguments);}
+		gtag('js', new Date());
+
+		gtag('config', 'UA-197061964-2');
+		</script>
 	</head>
 	<body>
 		<header id="header"></header>

--- a/contributors/index.html
+++ b/contributors/index.html
@@ -6,15 +6,15 @@
 		<link rel="stylesheet" type="text/css" href="../resources/stylesheet.css">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="Description" content="List of people who helped develop this site">
-		
-		<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-FGN5P806VX"></script>
-		<script>
-			window.dataLayer = window.dataLayer || [];
-			function gtag(){dataLayer.push(arguments);}
-			gtag('js', new Date());
 
-			gtag('config', 'G-FGN5P806VX');
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-197061964-2"></script>
+		<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag(){dataLayer.push(arguments);}
+		gtag('js', new Date());
+
+		gtag('config', 'UA-197061964-2');
 		</script>
 	</head>
 

--- a/forumhelpers/index.html
+++ b/forumhelpers/index.html
@@ -8,13 +8,13 @@
 		<meta name="Description" content="The list of all the Forum Helpers who are in the Scratch Forum Helpers studio, as well as their biographies.">
 
 		<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-FGN5P806VX"></script>
+		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-197061964-2"></script>
 		<script>
-			window.dataLayer = window.dataLayer || [];
-			function gtag(){dataLayer.push(arguments);}
-			gtag('js', new Date());
+		window.dataLayer = window.dataLayer || [];
+		function gtag(){dataLayer.push(arguments);}
+		gtag('js', new Date());
 
-			gtag('config', 'G-FGN5P806VX');
+		gtag('config', 'UA-197061964-2');
 		</script>
 	</head>
 

--- a/index.html
+++ b/index.html
@@ -8,13 +8,13 @@
 		<meta name="Description" content="The official website for the Scratch Forum Helpers. This contains information about who we are and what we do.">
 
 		<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-FGN5P806VX"></script>
+		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-197061964-2"></script>
 		<script>
-			window.dataLayer = window.dataLayer || [];
-			function gtag(){dataLayer.push(arguments);}
-			gtag('js', new Date());
+		window.dataLayer = window.dataLayer || [];
+		function gtag(){dataLayer.push(arguments);}
+		gtag('js', new Date());
 
-			gtag('config', 'G-FGN5P806VX');
+		gtag('config', 'UA-197061964-2');
 		</script>
 	</head>
 

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -8,13 +8,13 @@
 		<meta name="Description" content="The Forum Helpers site privacy policy.">
 
 		<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-FGN5P806VX"></script>
+		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-197061964-2"></script>
 		<script>
-			window.dataLayer = window.dataLayer || [];
-			function gtag(){dataLayer.push(arguments);}
-			gtag('js', new Date());
+		window.dataLayer = window.dataLayer || [];
+		function gtag(){dataLayer.push(arguments);}
+		gtag('js', new Date());
 
-			gtag('config', 'G-FGN5P806VX');
+		gtag('config', 'UA-197061964-2');
 		</script>
 	</head>
 


### PR DESCRIPTION
-Use Universal Analytics instead of GA4 so that the results can be filtered.

### Resolves:

Should Resolve #190 

### Changes:

-Use Universal Analytics instead of GA4 so that the results can be filtered.

### Local Tests:

Not tested locally, since Google Analytics won't work locally. I will test using a fork after this is merged.

@leahcimto 
