### PR TITLE
Add dark mode

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,7 +5,7 @@
 		<base href="https://theforumhelpers.github.io"> <!--If making local changes, change the base tag to point to how your filesystem is set up-->
 		<link rel="shortcut icon" type="image/png" href="resources/favicon.png">
 		<link rel="stylesheet" type="text/css" href="resources/stylesheet.css">
-		
+
 		<!-- Global site tag (gtag.js) - Google Analytics -->
 		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-197061964-2"></script>
 		<script>
@@ -24,7 +24,7 @@
 		<br>
 		<div class="lost_content">
 			<p>Hmmm... looks like you're lost. But don't worry! The magic taco can help you find your way back to the homepage. Just click on it!</p>
-			<a href="/" class="FHULink" alt="Magic Taco" title="Click me!"><img src="resources/Taco-wizard.svg"></a>
+			<a href="/" class="taco" alt="Magic Taco" title="Click me!"><img src="resources/Taco-wizard.svg"></a>
 		</div>
 		<script src="resources/imports.js" onload="reference('./');"></script>
 	</body>

--- a/forumhelpers/FHP.js
+++ b/forumhelpers/FHP.js
@@ -78,8 +78,8 @@ function checkUser() {
 		searchButton.title = "Search!";
 	}
 	else if (searchedUser != "") {
-		searchBar.style.borderColor = "red";
-		searchButton.style.borderColor = "red";
+		searchBar.style.borderColor = "#cc0000";
+		searchButton.style.borderColor = "#cc0000";
 		searchButton.disabled = true;
 		searchButton.title = "Invalid Username";
 	}

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -37,6 +37,7 @@
 			<ul>
 				<li>Aside from Google Analytics, this site also stores two cookies on your computer which save whether or not you have agreed to the use of Google Analytics, and the date that you agreed.</li><br>
 				<li>This cookie expires each month, so you will have to re-accept the use of Google Analytics when you visit our site in a month that you have not yet accepted.</li><br>
+				<li>We also store one cookie which does not expire that stores your theme choice (light mode vs dark mode).</li><br>
 				<li>Questions? Feel free to contact us by <a href="https://github.com/theforumhelpers/theforumhelpers.github.io/discussions/new?category=q-a">opening a discussion</a> on our GitHub repository.</li>
 			</ul>
 		</div>

--- a/resources/imports.js
+++ b/resources/imports.js
@@ -1,3 +1,11 @@
+var theme = localStorage.getItem("siteTheme");
+if (theme == "light" || theme == null) {
+	document.getElementsByTagName("html")[0].className = "lightMode";
+}
+else {
+	document.getElementsByTagName("html")[0].className = "darkMode";
+}
+
 function reference(link) {
 	const headerContent = `
 	<a href="${link}" target="_parent">
@@ -17,10 +25,12 @@ function reference(link) {
 
 	const footerContent = `
 	<div class="footer_content">
-			<p><a href="${link}contributors/" class="FHULink" target="_parent">Contributors</a></p>
-			<p><a href="https://github.com/theforumhelpers/theforumhelpers.github.io" class="FHULink" target="_parent">Github Repository</a></p>
-			<p>Be moist <img src="https://cdn.scratch.mit.edu/scratchr2/static/__4f1f321e080ee4987f163566ecc0dd26__/djangobb_forum/img/smilies/cool.png"></p>
-			<p style="font-size: 12px;">This site uses Google Analytics. Check out our <a href="${link}privacy/" class="FHULink" target="_parent">Privacy Policy</a> for more information</p>
+		<br>
+		<a onclick="changeTheme()" class="changeTheme">Change Theme</a><br>
+		<p><a href="${link}contributors/" class="FHULink" target="_parent">Contributors</a></p>
+		<p><a href="https://github.com/theforumhelpers/theforumhelpers.github.io" class="FHULink" target="_parent">Github Repository</a></p>
+		<p>Be moist <img src="https://cdn.scratch.mit.edu/scratchr2/static/__4f1f321e080ee4987f163566ecc0dd26__/djangobb_forum/img/smilies/cool.png"></p>
+		<p style="font-size: 12px;">This site uses Google Analytics. Check out our <a href="${link}privacy/" class="FHULink" target="_parent">Privacy Policy</a> for more information</p>
 	</div>`
 	document.getElementById("footer").innerHTML = footerContent;
 
@@ -49,4 +59,17 @@ function denyPrivacy() {
 	localStorage.removeItem("FHacceptedAnalytics");
 	localStorage.removeItem("FHacceptedDate");
 	window.location.href = "https://scratch.mit.edu/studios/3688309/";
+}
+
+function changeTheme() {
+	var theme = localStorage.getItem("siteTheme");
+	console.log(theme)
+	if (theme == "light" || theme == null) {
+		theme = "dark";
+	}
+	else {
+		theme = "light";
+	}
+	localStorage.setItem("siteTheme", theme)
+	document.getElementsByTagName("html")[0].className = theme + "Mode";
 }

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -1,9 +1,29 @@
 /* font import */
 @import url('https://fonts.googleapis.com/css2?family=Montserrat&display=swap');
 
+html.lightMode {
+	--primary: #B7E4E2;
+	--secondary: #31ACBA;
+	--secondaryHover: #056472;
+	--textPrimary: black;
+	--textSecondary: white;
+	--linkHover: blue;
+	--saturation: 100%;
+}
+
+html.darkMode {
+	--primary: #121212;
+	--secondary: #1f1f1f;
+	--secondaryHover: #121212;
+	--textPrimary: #C4C4C4;
+	--textSecondary: #C4C4C4;
+	--linkHover: #a1c6ff;
+	--saturation: 60%;
+}
+
 body {
 	margin:0;
-	background: #B7E4E2;
+	background: var(--primary);
 	}
 
 a {
@@ -19,15 +39,15 @@ a:visited:not(.nav_button):visited  {
 	}
 
 a:hover:not(.nav_button):hover {
-	color: blue;
+	color: var(--linkHover);
 	background-color: inherit;
 	text-decoration: underline;
 	}
 
 /*navbar*/
 header {
-	background: #31ACBA;
-	color: white;
+	background: var(--secondary);
+	color: var(--textSecondary);
 	font-size: 20px;
 	width: 100%;
 	height: 70px;
@@ -40,6 +60,7 @@ header {
 	height: 70px;
 	width: 70px;
 	box-sizing: border-box;
+	filter: saturate(var(--saturation));
 	user-drag: none;
 	user-select: none;
 	-moz-user-select: none;
@@ -59,9 +80,9 @@ header {
 	}
 
 .nav_button {
-	background-color: #31ACBA;
+	background-color: var(--secondary);
 	font-size: 16px;
-	color: white;
+	color: var(--textSecondary);
 	transition-duration: 0.4s;
 	padding: 25px 5px 25px 5px;
 	text-decoration: none;
@@ -72,11 +93,11 @@ header {
 	}
 
 .nav_button:hover {
-	background-color: #056472;
+	background-color: var(--secondaryHover);
 	}
 
 .expandableDropdown {
-	background-color: #31ACBA;
+	background-color: var(--secondary);
 	display: none;
 	width: 50px;
 	height: 50px;
@@ -88,7 +109,7 @@ header {
 
 .expandableLink {
 	display: none;
-	background-color: #31ACBA;
+	background-color: var(--secondary);
 	font-size: 16px;
 	color: white;
 	padding: 10px 5px 10px 5px;
@@ -144,7 +165,7 @@ header {
 
 /*Main Page*/
 .home_content {
-	color: black;
+	color: var(--textPrimary);
 	font-size: 20px;
 	width: 100%;
 	text-align: center;
@@ -162,6 +183,7 @@ header {
 .forumhelpers_content {
 	font-family: Arial, sans-serif;
 	margin-left: 20px;
+	color: var(--textPrimary);
 	}
 
 hr {
@@ -176,7 +198,7 @@ hr {
 	right: 5px;
 	bottom: 5px;
 	text-align: center;
-	background: #B7E4E2;
+	background: var(--primary);
 	}
 
 @media only screen and (max-width: 800px) {
@@ -194,6 +216,8 @@ hr {
 	outline: none;
 	box-sizing: border-box;
 	border-right: none;
+	background-color: var(--secondary);
+	color: var(--textPrimary);
 }
 
 #searchButton {
@@ -206,12 +230,12 @@ hr {
 	box-sizing: border-box;
 	margin-left: -7px;
 	border-left: none;
-	background-color: #31ACBA;
-	color: white;
+	background-color: var(--secondaryHover);
+	color: var(--textSecondary);
 }
 
 #searchButton:hover {
-	background-color: #56c4d1;
+	background-color: var(--secondary);
 }
 
 #searchButton:disabled, #searchButton:disabled:hover {
@@ -224,7 +248,7 @@ hr {
 
 .forumhelpers_subheaders{
 	width: fit-content;
-	background: #31ACBA;
+	background: var(--secondary);
 	padding: 10px;
 	border-radius: 10px;
 	}
@@ -251,6 +275,7 @@ hr {
 	margin-right: 10px;
 	height: 60px;
  	width: 60px;
+	filter: saturate(var(--saturation))
 	}
 
 .profileBio {
@@ -264,12 +289,13 @@ hr {
 	padding: 5px;
 	margin-right:20%;
 	width: fit-content;
+	filter: saturate(var(--saturation));
 }
  /*Forum Helpers List*/
 
 /*Credits*/
 .credits_content {
-	color: black;
+	color: var(--textPrimary);
 	font-size: 20px;
 	width: 100%;
 	text-align: center;
@@ -293,10 +319,11 @@ hr {
 .credits_pfp {
 	border-radius: 10px;
 	width: 100px;
+	filter: saturation(var(--saturation));
 }
 
 .credits_link {
-	color: black;
+	color: inherit;
 	text-decoration: none;
 	font-weight: bold;
 }
@@ -304,7 +331,7 @@ hr {
 
 /*Privacy*/
 .privacy_content {
-	color: black;
+	color: var(--textPrimary);
 	font-size: 20px;
 	width: 100%;
 	margin-top: 0px;
@@ -335,13 +362,14 @@ hr {
 }
 
 .privacyButton:hover {
-	background-color: lightgrey;
+	background-color: (lightgrey);
+	color: black;
 }
 /*Privacy*/
 
 /*404 (had to use lost since css won't use numbers at the start of class names*/
 .lost_title {
-	color:black;
+	color: var(--textPrimary);
 	text-align: center;
 	font-size: 30px;
 	font-family: Arial, sans-serif;
@@ -349,16 +377,19 @@ hr {
 }
 
 .lost_content {
-	color:black;
+	color: var(--textPrimary);
 	text-align: center;
 	font-size: 20px;
 	font-family: Arial, sans-serif;
+}
 
+.taco {
+	filter: saturate(var(--saturation))
 }
 /*Footer*/
 .footer_content {
-	background: #31ACBA;
-	color: white;
+	background: var(--secondary);
+	color: var(--textSecondary);
 	font-size: 20px;
 	width: 100%;
 	padding: 10px;
@@ -369,5 +400,11 @@ hr {
 	line-height: 10px;
 	height: auto;
 }
+.changeTheme {
+	display: block;
+}
 
+.changeTheme:hover {
+	cursor: pointer;
+}
 /*Footer*/

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -8,6 +8,7 @@ html.lightMode {
 	--textPrimary: black;
 	--textSecondary: white;
 	--linkHover: blue;
+	--searchBar: white;
 	--saturation: 100%;
 }
 
@@ -18,6 +19,7 @@ html.darkMode {
 	--textPrimary: #C4C4C4;
 	--textSecondary: #C4C4C4;
 	--linkHover: #a1c6ff;
+	--searchBar: #1f1f1f;
 	--saturation: 60%;
 }
 
@@ -216,7 +218,7 @@ hr {
 	outline: none;
 	box-sizing: border-box;
 	border-right: none;
-	background-color: var(--secondary);
+	background-color: var(--searchBar);
 	color: var(--textPrimary);
 }
 
@@ -230,12 +232,12 @@ hr {
 	box-sizing: border-box;
 	margin-left: -7px;
 	border-left: none;
-	background-color: var(--secondaryHover);
+	background-color: var(--secondary);
 	color: var(--textSecondary);
 }
 
 #searchButton:hover {
-	background-color: var(--secondary);
+	background-color: var(--secondaryHover);
 }
 
 #searchButton:disabled, #searchButton:disabled:hover {


### PR DESCRIPTION
### Resolves:

Resolves #135 

### Changes:

- Adds dark mode to the site by using CSS variables
    - The default theme is light mode and there are two themes- light and dark
      - In dark mode, the background colours are a dark grey and text is a near-white colour
      - Links are a lighter blue for better contrast
      - Images and ocular statuses have decreased saturation so they are easier on the eyes
    - The button to switch themes is in the footer
    - The user's choice is recorded as a localStorage item so the theme is the same the next time they visit the site
    - Updates the privacy policy to inform the user of this additional localStorage item


To Do:
- Make the default theme that of the user's device.
- Update the change theme button better (right now it is just a link)
- Add more themes (eg. Scratch Theme)

### Local Tests:

Tested locally. I also used a colour contrast checker to ensure that there is adequate contrast between the text and the background.

@leahcimto @gosoccerboy5 @Steve0Greatness
