### PR TITLE
Improve theme switch interface

### DIFF
--- a/404.html
+++ b/404.html
@@ -27,5 +27,6 @@
 			<a href="/" class="taco" alt="Magic Taco" title="Click me!"><img src="resources/Taco-wizard.svg"></a>
 		</div>
 		<script src="resources/imports.js" onload="reference('./');"></script>
+		<script src="resources/theme.js"></script>
 	</body>
 </html>

--- a/contributors/index.html
+++ b/contributors/index.html
@@ -45,6 +45,7 @@
 
 		<footer id="footer"></footer>
 		<script src="../resources/imports.js" onload='reference("../")'></script>
+		<script src="../resources/theme.js"></script>
 		<script>
 			var contributors = ["Accio1", "leahcimto", "NilsTheBest", "Nambaseking01", "shefwerld", "FunctionalMetatable", "ShadowOfTheFuture", "Shluffy", "bremea", "gosoccerboy5", "TheColaber", "awesome-llama", "CodeGuy92", "jeffalo", "MTM828", "The64thCucumber"]
 

--- a/forumhelpers/index.html
+++ b/forumhelpers/index.html
@@ -63,6 +63,7 @@
 
 	<footer id="footer"></footer>
 	<script src="../resources/imports.js" onload='reference("../")'></script>
+	<script src="../resources/theme.js"></script>
 	<script src="FHP.js"></script>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -39,5 +39,6 @@
 
 		<footer id="footer"></footer>
 		<script src="resources/imports.js" onload='reference("")'></script>
+		<script src="resources/theme.js"></script>
 	</body>
 </html>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -44,5 +44,6 @@
 
 		<footer id="footer"></footer>
 		<script src="../resources/imports.js" onload='reference("../")'></script>
+		<script src="../resources/theme.js"></script>
 	</body>
 </html>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -37,7 +37,7 @@
 			<ul>
 				<li>Aside from Google Analytics, this site also stores two cookies on your computer which save whether or not you have agreed to the use of Google Analytics, and the date that you agreed.</li><br>
 				<li>This cookie expires each month, so you will have to re-accept the use of Google Analytics when you visit our site in a month that you have not yet accepted.</li><br>
-				<li>We also store one cookie which does not expire that stores your theme choice (light mode vs dark mode).</li><br>
+				<li>We also store one cookie which does not expire that stores your theme choice.</li><br>
 				<li>Questions? Feel free to contact us by <a href="https://github.com/theforumhelpers/theforumhelpers.github.io/discussions/new?category=q-a">opening a discussion</a> on our GitHub repository.</li>
 			</ul>
 		</div>

--- a/resources/imports.js
+++ b/resources/imports.js
@@ -1,18 +1,24 @@
-var theme = localStorage.getItem("siteTheme");
-if (theme == null){
-	if (window.matchMedia('(prefers-color-scheme: dark)').matches){
-		theme = "dark";
-	}
-	else {
-		theme = "light";
-	}
-}
-if (theme == "light") {
-	document.getElementsByTagName("html")[0].className = "lightMode";
-}
-else {
-	document.getElementsByTagName("html")[0].className = "darkMode";
-}
+// // Theme
+// var theme = localStorage.getItem("siteTheme");
+
+// if (theme == null){
+// 	if (window.matchMedia('(prefers-color-scheme: dark)').matches){
+// 		theme = "dark";
+// 	}
+// 	else {
+// 		theme = "light";
+// 	}
+// }
+
+// if (theme == "light") {
+// 	document.getElementsByTagName("html")[0].className = "lightMode";
+// }
+// else {
+// 	document.getElementsByTagName("html")[0].className = "darkMode";
+// }
+
+// var themeButton = document.getElementById("changeTheme");
+// themeButton.innerHTML = "Change Theme (" + theme + ")";
 
 function reference(link) {
 	const headerContent = `
@@ -69,15 +75,16 @@ function denyPrivacy() {
 	window.location.href = "https://scratch.mit.edu/studios/3688309/";
 }
 
-function changeTheme() {
-	var theme = localStorage.getItem("siteTheme");
-	console.log(theme)
-	if (theme == "light" || theme == null) {
-		theme = "dark";
-	}
-	else {
-		theme = "light";
-	}
-	localStorage.setItem("siteTheme", theme)
-	document.getElementsByTagName("html")[0].className = theme + "Mode";
-}
+// function changeTheme() {
+// 	var theme = localStorage.getItem("siteTheme");
+// 	console.log(theme)
+// 	if (theme == "light" || theme == null) {
+// 		theme = "dark";
+// 	}
+// 	else {
+// 		theme = "light";
+// 	}
+// 	localStorage.setItem("siteTheme", theme)
+// 	document.getElementsByTagName("html")[0].className = theme + "Mode";
+// 	themeButton.innerHTML = "Change Theme (" + theme + ")";
+// }

--- a/resources/imports.js
+++ b/resources/imports.js
@@ -1,25 +1,3 @@
-// // Theme
-// var theme = localStorage.getItem("siteTheme");
-
-// if (theme == null){
-// 	if (window.matchMedia('(prefers-color-scheme: dark)').matches){
-// 		theme = "dark";
-// 	}
-// 	else {
-// 		theme = "light";
-// 	}
-// }
-
-// if (theme == "light") {
-// 	document.getElementsByTagName("html")[0].className = "lightMode";
-// }
-// else {
-// 	document.getElementsByTagName("html")[0].className = "darkMode";
-// }
-
-// var themeButton = document.getElementById("changeTheme");
-// themeButton.innerHTML = "Change Theme (" + theme + ")";
-
 function reference(link) {
 	const headerContent = `
 	<a href="${link}" target="_parent">
@@ -74,17 +52,3 @@ function denyPrivacy() {
 	localStorage.removeItem("FHacceptedDate");
 	window.location.href = "https://scratch.mit.edu/studios/3688309/";
 }
-
-// function changeTheme() {
-// 	var theme = localStorage.getItem("siteTheme");
-// 	console.log(theme)
-// 	if (theme == "light" || theme == null) {
-// 		theme = "dark";
-// 	}
-// 	else {
-// 		theme = "light";
-// 	}
-// 	localStorage.setItem("siteTheme", theme)
-// 	document.getElementsByTagName("html")[0].className = theme + "Mode";
-// 	themeButton.innerHTML = "Change Theme (" + theme + ")";
-// }

--- a/resources/imports.js
+++ b/resources/imports.js
@@ -1,5 +1,13 @@
 var theme = localStorage.getItem("siteTheme");
-if (theme == "light" || theme == null) {
+if (theme == null){
+	if (window.matchMedia('(prefers-color-scheme: dark)').matches){
+		theme = "dark";
+	}
+	else {
+		theme = "light";
+	}
+}
+if (theme == "light") {
 	document.getElementsByTagName("html")[0].className = "lightMode";
 }
 else {

--- a/resources/imports.js
+++ b/resources/imports.js
@@ -26,7 +26,7 @@ function reference(link) {
 	const footerContent = `
 	<div class="footerContent">
 		<br>
-		<a onclick="changeTheme()" class="changeTheme">Change Theme</a><br>
+		<a onclick="changeTheme()" class="changeTheme" id="changeTheme">Change Theme</a><br>
 		<p><a href="${link}contributors/" class="FHULink" target="_parent">Contributors</a></p>
 		<p><a href="https://github.com/theforumhelpers/theforumhelpers.github.io" class="FHULink" target="_parent">Github Repository</a></p>
 		<p>Be moist <img src="https://cdn.scratch.mit.edu/scratchr2/static/__4f1f321e080ee4987f163566ecc0dd26__/djangobb_forum/img/smilies/cool.png"></p>

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -422,6 +422,7 @@ hr {
 	border-style: hidden;
 	border-radius: 10px;
 	display: inline-block;
+	user-select: none; /* Repeatedly cliking the button should not select it */
 }
 
 #changeTheme:hover {

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -413,11 +413,19 @@ hr {
 	line-height: 10px;
 	height: auto;
 }
-.changeTheme {
-	display: block;
+
+#changeTheme {
+	background-color: #2f75a3;
+	padding: 20px;
+	border-style: hidden;
+	border-radius: 10px;
+	display: inline-block;
+	margin: 10px;
+	text-decoration: none;
 }
 
-.changeTheme:hover {
+#changeTheme:hover {
 	cursor: pointer;
+	color: #A1C6FF;
 }
 /* /Footer */

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -416,12 +416,12 @@ hr {
 
 #changeTheme {
 	background-color: #2f75a3;
+	text-decoration: none;
+	margin: 10px;
 	padding: 20px;
 	border-style: hidden;
 	border-radius: 10px;
 	display: inline-block;
-	margin: 10px;
-	text-decoration: none;
 }
 
 #changeTheme:hover {

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -10,6 +10,8 @@ html.lightMode {
 	--linkHover: blue;
 	--searchBar: white;
 	--saturation: 100%;
+	--tertiary: #2f7299;
+	--tertiaryHover: #2c566e;
 }
 
 html.darkMode {
@@ -21,6 +23,8 @@ html.darkMode {
 	--linkHover: #a1c6ff;
 	--searchBar: #1f1f1f;
 	--saturation: 60%;
+	--tertiary: #3d4042;
+	--tertiaryHover: #27292c;
 }
 
 body {
@@ -415,7 +419,7 @@ hr {
 }
 
 #changeTheme {
-	background-color: #2f75a3;
+	background-color: var(--tertiary);
 	text-decoration: none;
 	margin: 10px;
 	padding: 20px;
@@ -428,5 +432,6 @@ hr {
 #changeTheme:hover {
 	cursor: pointer;
 	color: #A1C6FF;
+	background-color: var(--tertiaryHover);
 }
 /* /Footer */

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -12,6 +12,7 @@ html.lightMode {
 	--saturation: 100%;
 	--tertiary: #2f7299;
 	--tertiaryHover: #2c566e;
+	--textTertiary: #ffffff;
 }
 
 html.darkMode {
@@ -431,7 +432,7 @@ hr {
 
 #changeTheme:hover {
 	cursor: pointer;
-	color: #A1C6FF;
+	color: var(--textTertiary);
 	background-color: var(--tertiaryHover);
 }
 /* /Footer */

--- a/resources/theme.js
+++ b/resources/theme.js
@@ -5,8 +5,6 @@ if (theme == null){
 	theme = "system";
 }
 
-themeButton.innerHTML = `Change Theme (${theme})`;
-
 function checkSystemTheme() {
 	if (window.matchMedia('(prefers-color-scheme: dark)').matches){
 		return "dark";
@@ -17,21 +15,11 @@ function checkSystemTheme() {
 }
 
 if (theme == "system") {
-	var systemTheme = checkSystemTheme();
-	if (systemTheme == "light") {
-		document.getElementsByTagName("html")[0].className = "lightMode";
-	}
-	else {
-		document.getElementsByTagName("html")[0].className = "darkMode";
-	}
-} 
-else if (theme == "light") {
-	document.getElementsByTagName("html")[0].className = "lightMode";
-} 
-else {
-	document.getElementsByTagName("html")[0].className = "darkMode";
+	setTheme("system")
 }
-
+else {
+	setTheme(theme)
+}
 
 function changeTheme() {
 	// Currently Available themes: system, light, dark
@@ -39,8 +27,7 @@ function changeTheme() {
 	var theme = localStorage.getItem("siteTheme");
 	var listOfThemes = ["system", "light", "dark"];
 	var indexOfCurrentTheme = listOfThemes.indexOf(theme);
-	console.log(theme);
-	
+
 	if (indexOfCurrentTheme < listOfThemes.length - 1){
 		theme = listOfThemes[indexOfCurrentTheme + 1];
 	}
@@ -48,19 +35,19 @@ function changeTheme() {
 		theme = listOfThemes[0];
 	}
 
-	localStorage.setItem("siteTheme", theme)
-
 	if (theme == "system"){
-		var systemTheme = checkSystemTheme();
-		if (systemTheme == "light") {
-			document.getElementsByTagName("html")[0].className = "lightMode";
-		}
-		else {
-			document.getElementsByTagName("html")[0].className = "darkMode";
-		}
+			setTheme("system")
 	}
 	else {
-		document.getElementsByTagName("html")[0].className = theme + "Mode";
+		setTheme(theme)
 	}
+}
+
+function setTheme(theme) {
+	localStorage.setItem("siteTheme", theme)
 	themeButton.innerHTML = `Change Theme (${theme})`;
+	if (theme == "system") {
+		var theme = checkSystemTheme()
+	}
+	document.getElementsByTagName("html")[0].className = theme + "Mode";
 }

--- a/resources/theme.js
+++ b/resources/theme.js
@@ -1,0 +1,33 @@
+var theme = localStorage.getItem("siteTheme");
+var themeButton = document.getElementById("changeTheme");
+themeButton.innerHTML = "Change Theme (" + theme + ")";
+
+if (theme == null){
+	if (window.matchMedia('(prefers-color-scheme: dark)').matches){
+		theme = "dark";
+	}
+	else {
+		theme = "light";
+	}
+}
+
+if (theme == "light") {
+	document.getElementsByTagName("html")[0].className = "lightMode";
+}
+else {
+	document.getElementsByTagName("html")[0].className = "darkMode";
+}
+
+function changeTheme() {
+	var theme = localStorage.getItem("siteTheme");
+	console.log(theme)
+	if (theme == "light" || theme == null) {
+		theme = "dark";
+	}
+	else {
+		theme = "light";
+	}
+	localStorage.setItem("siteTheme", theme)
+	document.getElementsByTagName("html")[0].className = theme + "Mode";
+	themeButton.innerHTML = "Change Theme (" + theme + ")";
+}

--- a/resources/theme.js
+++ b/resources/theme.js
@@ -1,33 +1,66 @@
 var theme = localStorage.getItem("siteTheme");
 var themeButton = document.getElementById("changeTheme");
-themeButton.innerHTML = "Change Theme (" + theme + ")";
 
 if (theme == null){
+	theme = "system";
+}
+
+themeButton.innerHTML = "Change Theme (" + theme + ")";
+
+function checkSystemTheme() {
 	if (window.matchMedia('(prefers-color-scheme: dark)').matches){
-		theme = "dark";
+		return "dark";
 	}
 	else {
-		theme = "light";
+		return "light";
 	}
 }
 
-if (theme == "light") {
+if (theme == "system") {
+	var systemTheme = checkSystemTheme();
+	if (systemTheme == "light") {
+		document.getElementsByTagName("html")[0].className = "lightMode";
+	}
+	else {
+		document.getElementsByTagName("html")[0].className = "darkMode";
+	}
+} 
+else if (theme == "light") {
 	document.getElementsByTagName("html")[0].className = "lightMode";
-}
+} 
 else {
 	document.getElementsByTagName("html")[0].className = "darkMode";
 }
 
+
 function changeTheme() {
+	// Currently Available themes: system, light, dark
+	// If you are adding a theme, please update the comment above and the array below
 	var theme = localStorage.getItem("siteTheme");
-	console.log(theme)
-	if (theme == "light" || theme == null) {
-		theme = "dark";
+	var listOfThemes = ["system", "light", "dark"];
+	var indexOfCurrentTheme = listOfThemes.indexOf(theme);
+	console.log(theme);
+	
+	if (indexOfCurrentTheme < listOfThemes.length - 1){
+		theme = listOfThemes[indexOfCurrentTheme + 1];
 	}
 	else {
-		theme = "light";
+		theme = listOfThemes[0];
 	}
+
 	localStorage.setItem("siteTheme", theme)
-	document.getElementsByTagName("html")[0].className = theme + "Mode";
+
+	if (theme == "system"){
+		var systemTheme = checkSystemTheme();
+		if (systemTheme == "light") {
+			document.getElementsByTagName("html")[0].className = "lightMode";
+		}
+		else {
+			document.getElementsByTagName("html")[0].className = "darkMode";
+		}
+	}
+	else {
+		document.getElementsByTagName("html")[0].className = theme + "Mode";
+	}
 	themeButton.innerHTML = "Change Theme (" + theme + ")";
 }

--- a/resources/theme.js
+++ b/resources/theme.js
@@ -5,7 +5,7 @@ if (theme == null){
 	theme = "system";
 }
 
-themeButton.innerHTML = "Change Theme (" + theme + ")";
+themeButton.innerHTML = `Change Theme (${theme})`;
 
 function checkSystemTheme() {
 	if (window.matchMedia('(prefers-color-scheme: dark)').matches){
@@ -62,5 +62,5 @@ function changeTheme() {
 	else {
 		document.getElementsByTagName("html")[0].className = theme + "Mode";
 	}
-	themeButton.innerHTML = "Change Theme (" + theme + ")";
+	themeButton.innerHTML = `Change Theme (${theme})`;
 }


### PR DESCRIPTION
### Resolves:
None.

### Changes:
- Added Button to change theme. It is at the bottom of most pages (except the 404 page - since its a part of the footer)
- That button is still a link! It was just modified to make it look like a button. Also, the ablility to select the element was disabled because anyone repeatedly clicking the button to cycle through themes should be able to do so without it automatically being selected.
- The button also gives information about the current website theme.
- Adds system theme detection. On first launch, if no theme value is set in the cookie, it defaults to the system theme.
- Creates a JS file ```theme.js``` for theme-related Javascript code. It is located in the ```resources``` folder.
- Also, allows a user to switch to system theme. Earlier, it was not possible for the website the detect the system theme.
- This does more that just adding a button and "system theme" but also makes it easier to add themes in the future! In the future, adding a theme will only require adding the theme name to an array and specify css variables.

### Local Tests:
I tested it a lot locally using localhost to simulate an actual server. I couldn't discover any bugs. Here are some screenshots:

When set to system theme:
![image](https://user-images.githubusercontent.com/83728060/121526168-3144ac80-ca0a-11eb-83a8-fff47e931ac2.png)

When set to light theme:
![image](https://user-images.githubusercontent.com/83728060/121526215-386bba80-ca0a-11eb-935d-4342937ef5dd.png)

When set to dark theme:
![image](https://user-images.githubusercontent.com/83728060/121526243-3efa3200-ca0a-11eb-8ffb-bb6a292b48f9.png)

It would be great if you let me know of any bugs, you can try it out [here ](https://barelysmooth.github.io/theforumhelpers.github.io/)without cloning the repository locally.

Also, @Accio1 I think you should change the second to last point in the Privacy Policy, now that themes aren't limited to light/dark