### PR TITLE
Change the search bar color in dark mode

### DIFF
--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -22,7 +22,7 @@ html.darkMode {
 	--textPrimary: #C4C4C4;
 	--textSecondary: #C4C4C4;
 	--linkHover: #a1c6ff;
-	--searchBar: #1f1f1f;
+	--searchBar: #222b2e;
 	--saturation: 60%;
 	--tertiary: #3d4042;
 	--tertiaryHover: #27292c;


### PR DESCRIPTION
### Resolves:

#216 

### Changes:

changes the `--searchBar:` part of `html.darkMode` to `#222b2e` rather then `#1f1f1f`, which blends into the search button when it has a match

### Local Tests:

#216 contains some screenshots and stuff about how this would work, or see the image below.
![image](https://user-images.githubusercontent.com/81823039/121237661-4d5b1900-c865-11eb-8f34-06f21e300c1e.png)