### PR TITLE
Fix 404 page styling

### DIFF
--- a/resources/theme.js
+++ b/resources/theme.js
@@ -45,7 +45,9 @@ function changeTheme() {
 
 function setTheme(theme) {
 	localStorage.setItem("siteTheme", theme)
-	themeButton.innerHTML = `Change Theme (${theme})`;
+	if (themeButton !== null) {
+		themeButton.innerHTML = `Change Theme (${theme})`;
+	}
 	if (theme == "system") {
 		var theme = checkSystemTheme()
 	}


### PR DESCRIPTION
### Resolves:
A bug introduced in #226 which broke the theme on the the 404 page. The reason this happened was because the code tried to set the ```innerHTML``` of the "Change Theme" button. But since the 404 page didn't have a footer, there was no button and hence it interfered with the theme.

### Changes:
Adds an if statement to change the button's ```innerHTML``` only if the button exists.

### Local Tests:
I tested this locally (by changing the ```<base>``` tag in ```404.html```). The page then loaded the theme fine.
