### PR TITLE
Add Search Dropdown

### DIFF
--- a/forumhelpers/FHP.js
+++ b/forumhelpers/FHP.js
@@ -1,13 +1,13 @@
-var membersList = []
+var membersList = [];
 function getData(dataSet) {
-	var grabDelay = 0
+	var grabDelay = 0;
 	fetch("https://theforumhelpers.github.io/forumhelpers/"+dataSet+".json")
 		.then(response => response.json())
 		.then(data => {
 			document.getElementById(dataSet+"Number").innerHTML = data.length;
 			for (j = 0; j < data.length; j++) {
 				var name = data[j].name;
-				membersList.push(name)
+				membersList.push(name);
 				var id = data[j].id;
 				var bio = data[j].bio;
 				var section = document.getElementById(dataSet+"List").innerHTML;
@@ -75,7 +75,7 @@ var searchOptions = [];
 function updateUserChoice() {
 	document.getElementById("searchOptions").innerHTML = "";
 	searchOptions = [];
-	var searchedLetters = searchBar.value
+	var searchedLetters = searchBar.value;
 	for (k = 0; k < membersList.length; k++) {
 		if (membersList[k].toUpperCase().includes(searchedLetters.toUpperCase()) && searchOptions.length != 5 && searchedLetters != "") {
 			searchOptions.push(membersList[k]);
@@ -94,6 +94,7 @@ function autoFill(fillValue) {
 	searchBar.value = fillValue;
 	checkUser();
 	updateUserChoice();
+	searchUser();
 }
 
 function checkUser() {

--- a/forumhelpers/FHP.js
+++ b/forumhelpers/FHP.js
@@ -19,8 +19,9 @@ function getData(dataSet) {
 						<p class="profileBio">${bio}</p>
 					</div>
 					<p class="ocularStatusBox" id="${name}Ocular" title="Ocular Status"><span class="ocularStatus" id="${name}Status">Loading Status...</span></p>
-				</div>
-				<hr>`;
+					<br>
+					<hr>
+				</div>`;
 				document.getElementById(dataSet+"List").innerHTML = section + addition;
 				if (j == data.length-1 && dataSet != "curators") {
 					getData("curators");
@@ -72,21 +73,43 @@ var searchBar = document.getElementById("searchBar");
 var searchButton = document.getElementById("searchButton");
 
 var searchOptions = [];
+var complexSearch = 0;
 function updateUserChoice() {
 	document.getElementById("searchOptions").innerHTML = "";
 	searchOptions = [];
 	var searchedLetters = searchBar.value;
-	for (k = 0; k < membersList.length; k++) {
-		if (membersList[k].toUpperCase().includes(searchedLetters.toUpperCase()) && searchOptions.length != 5 && searchedLetters != "") {
-			searchOptions.push(membersList[k]);
+	if (complexSearch == 0) {
+		for (k = 0; k < membersList.length; k++) {
+			if (membersList[k].toUpperCase().includes(searchedLetters.toUpperCase()) && searchOptions.length != 5 && searchedLetters != "") {
+				searchOptions.push(membersList[k]);
+			}
+			document.getElementById(membersList[k].toUpperCase()).style.display = "block";
+		}
+
+		for (k = 0; k < searchOptions.length; k++) {
+			var searchOptionBox = document.createElement("DIV");
+			searchOptionBox.innerText = searchOptions[k];
+			searchOptionBox.setAttribute("class", "searchOption");
+			searchOptionBox.setAttribute("onclick", `autoFill("${searchOptions[k]}")`);
+			document.getElementById("searchOptions").appendChild(searchOptionBox);
 		}
 	}
-	for (k = 0; k < searchOptions.length; k++) {
-		var searchOptionBox = document.createElement("DIV");
-		searchOptionBox.innerText = searchOptions[k];
-		searchOptionBox.setAttribute("class", "searchOption");
-		searchOptionBox.setAttribute("onclick", `autoFill("${searchOptions[k]}")`);
-		document.getElementById("searchOptions").appendChild(searchOptionBox);
+	else if (complexSearch == 1) {
+		for (k = 0; k < membersList.length; k++) {
+			if (membersList[k].toUpperCase().includes(searchedLetters.toUpperCase())) {
+				searchOptions.push(membersList[k].toUpperCase());
+			}
+		}
+
+		var profileContainers = document.getElementById("forumHelpersList").getElementsByClassName("profileContainer");
+		for (k = 0; k < profileContainers.length; k++) {
+			if (searchOptions.includes(profileContainers[k].id) == false) {
+				profileContainers[k].style.display = "none";
+			}
+			else {
+				profileContainers[k].style.display = "block";
+			}
+		}
 	}
 }
 
@@ -95,6 +118,17 @@ function autoFill(fillValue) {
 	checkUser();
 	updateUserChoice();
 	searchUser();
+}
+
+function hideMatchingResults() {
+	var searchCheckbox = document.getElementById("searchCheckbox");
+	if (searchCheckbox.checked == true) {
+		complexSearch = 1;
+	}
+	else {
+		complexSearch = 0;
+	}
+	updateUserChoice();
 }
 
 function checkUser() {

--- a/forumhelpers/FHP.js
+++ b/forumhelpers/FHP.js
@@ -1,3 +1,4 @@
+var membersList = []
 function getData(dataSet) {
 	var grabDelay = 0
 	fetch("https://theforumhelpers.github.io/forumhelpers/"+dataSet+".json")
@@ -6,6 +7,7 @@ function getData(dataSet) {
 			document.getElementById(dataSet+"Number").innerHTML = data.length;
 			for (j = 0; j < data.length; j++) {
 				var name = data[j].name;
+				membersList.push(name)
 				var id = data[j].id;
 				var bio = data[j].bio;
 				var section = document.getElementById(dataSet+"List").innerHTML;
@@ -66,8 +68,33 @@ function getCount(name) {
 
 
 //Search for a user
-var searchBar = document.getElementById("searchBar")
-var searchButton = document.getElementById("searchButton")
+var searchBar = document.getElementById("searchBar");
+var searchButton = document.getElementById("searchButton");
+
+var searchOptions = [];
+function updateUserChoice() {
+	document.getElementById("searchOptions").innerHTML = "";
+	searchOptions = [];
+	var searchedLetters = searchBar.value
+	for (k = 0; k < membersList.length; k++) {
+		if (membersList[k].toUpperCase().includes(searchedLetters.toUpperCase()) && searchOptions.length != 5 && searchedLetters != "") {
+			searchOptions.push(membersList[k]);
+		}
+	}
+	for (k = 0; k < searchOptions.length; k++) {
+		var searchOptionBox = document.createElement("DIV");
+		searchOptionBox.innerText = searchOptions[k];
+		searchOptionBox.setAttribute("class", "searchOption");
+		searchOptionBox.setAttribute("onclick", `autoFill("${searchOptions[k]}")`);
+		document.getElementById("searchOptions").appendChild(searchOptionBox);
+	}
+}
+
+function autoFill(fillValue) {
+	searchBar.value = fillValue;
+	checkUser();
+	updateUserChoice();
+}
 
 function checkUser() {
 	var searchedUser = searchBar.value.toUpperCase();

--- a/forumhelpers/FHP.js
+++ b/forumhelpers/FHP.js
@@ -71,9 +71,18 @@ function getCount(name) {
 //Search for a user
 var searchBar = document.getElementById("searchBar");
 var searchButton = document.getElementById("searchButton");
+var complexSearch
+var storedSearchOption = localStorage.getItem("complexSearch")
+if (storedSearchOption == false || storedSearchOption == null) {
+	document.getElementById("searchCheckbox").checked = false;
+	complexSearch = 0;
+}
+else {
+	document.getElementById("searchCheckbox").checked = true;
+	complexSearch = 1;
+}
 
 var searchOptions = [];
-var complexSearch = 0;
 function updateUserChoice() {
 	document.getElementById("searchOptions").innerHTML = "";
 	searchOptions = [];
@@ -124,9 +133,11 @@ function hideMatchingResults() {
 	var searchCheckbox = document.getElementById("searchCheckbox");
 	if (searchCheckbox.checked == true) {
 		complexSearch = 1;
+		localStorage.setItem("complexSearch", true);
 	}
 	else {
 		complexSearch = 0;
+		localStorage.setItem("complexSearch", false);
 	}
 	updateUserChoice();
 }

--- a/forumhelpers/index.html
+++ b/forumhelpers/index.html
@@ -46,6 +46,9 @@
 			<input type="text" id="searchBar" placeholder="Username" oninput="checkUser(), updateUserChoice()" onkeydown="if (event.keyCode == 13); document.getElementById('searchButton').click()">
 			<button id="searchButton" onclick="searchUser()" disabled title="Invalid Username">Search</button>
 			<div id="searchOptions"></div>
+			<br>
+			<input type="checkbox" id="searchCheckbox" onchange="hideMatchingResults()">
+			<label for="searchCheckbox"> Only show matching results?</label>
 		</div>
 
 		<div class="forumHelpersNavBlock">
@@ -53,11 +56,12 @@
 			<h3><a href="#managers" class="FHULink">Managers</a></h3>
 			<h3><a href="#curators" class="FHULink">Curators</a></h3>
 		</div>
-
-		<h1 class="forumHelpersSubheaders" id="managers">Managers</h1>
-		<div id="managersList"></div>
-		<h1 class="forumHelpersSubheaders" id="curators">Curators</h1>
-		<div id="curatorsList"></div>
+		<div class="forumHelpersList" id="forumHelpersList">
+			<h1 class="forumHelpersSubheaders" id="managers">Managers</h1>
+			<div id="managersList"></div>
+			<h1 class="forumHelpersSubheaders" id="curators">Curators</h1>
+			<div id="curatorsList"></div>
+		</div>
 	</div>
 
 	<div class="privacyWarning" id="privacyWarning"></div>

--- a/forumhelpers/index.html
+++ b/forumhelpers/index.html
@@ -43,8 +43,9 @@
 
 		<div class="searchBlock">
 			<h3>Search for a Forum Helper</h3>
-			<input type="text" id="searchBar" placeholder="Username" oninput="checkUser()">
+			<input type="text" id="searchBar" placeholder="Username" oninput="checkUser(), updateUserChoice()">
 			<button id="searchButton" onclick="searchUser()" disabled title="Invalid Username">Search</button>
+			<div id="searchOptions"></div>
 		</div>
 
 		<div class="forumHelpersNavBlock">

--- a/forumhelpers/index.html
+++ b/forumhelpers/index.html
@@ -43,7 +43,7 @@
 
 		<div class="searchBlock">
 			<h3>Search for a Forum Helper</h3>
-			<input type="text" id="searchBar" placeholder="Username" oninput="checkUser(), updateUserChoice()">
+			<input type="text" id="searchBar" placeholder="Username" oninput="checkUser(), updateUserChoice()" onkeydown="if (event.keyCode == 13); document.getElementById('searchButton').click()">
 			<button id="searchButton" onclick="searchUser()" disabled title="Invalid Username">Search</button>
 			<div id="searchOptions"></div>
 		</div>

--- a/forumhelpers/index.html
+++ b/forumhelpers/index.html
@@ -47,6 +47,7 @@
 			<button id="searchButton" onclick="searchUser()" disabled title="Invalid Username">Search</button>
 			<div id="searchOptions"></div>
 			<br>
+			<br>
 			<input type="checkbox" id="searchCheckbox" onchange="hideMatchingResults()">
 			<label for="searchCheckbox"> Only show matching results?</label>
 		</div>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -37,7 +37,7 @@
 			<ul>
 				<li>Aside from Google Analytics, this site also stores two cookies on your computer which save whether or not you have agreed to the use of Google Analytics, and the date that you agreed.</li><br>
 				<li>This cookie expires each month, so you will have to re-accept the use of Google Analytics when you visit our site in a month that you have not yet accepted.</li><br>
-				<li>We also store one cookie which does not expire that stores your theme choice.</li><br>
+				<li>We also store one cookie which does not expire that stores your theme choice, as well as one that stores your search options.</li><br>
 				<li>Questions? Feel free to contact us by <a href="https://github.com/theforumhelpers/theforumhelpers.github.io/discussions/new?category=q-a">opening a discussion</a> on our GitHub repository.</li>
 			</ul>
 		</div>

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -252,6 +252,7 @@ hr {
 #searchBar {
 	padding: 10px;
 	width: 40%;
+	min-width: 175px;
 	height: 50px;
 	border-radius: 10px 0px 0px 10px;
 	border: 4px solid black;
@@ -283,6 +284,33 @@ hr {
 #searchButton:disabled,
 #searchButton:disabled:hover {
 	background-color: grey;
+}
+
+#searchOptions {
+	border-radius: 10px;
+	margin-top: 2px;
+	width: 40%;
+	min-width: 175px;
+	box-sizing: border-box;
+	background-color: var(--secondary);
+	color: var(--textSecondary);
+	box-shadow: 1px 1px 10px #363636;
+}
+
+#searchOptions:empty {
+	display: none;
+}
+
+.searchOption {
+	padding: 5px;
+	width: 100%;
+	box-sizing: border-box;
+	border-radius: 10px;
+}
+
+.searchOption:hover {
+	cursor: pointer;
+	background-color: var(--secondaryHover);
 }
 
 .forumHelpersHeader {


### PR DESCRIPTION
### Resolves:

Resolves #257 

### Changes:

-Adds a search dropdown
-The search dropdown will display search suggestions based on what a user has typed into the search bar.
-Only 5 suggestions will be shown at once, so typing in "a" will display the first 5 users with "a" in their name.
-Case insensitive
-Clicking on a suggestion will input that user into the search bar.

### Local Tests:

Tested locally. Feel free to test and see if you can find a way to break it.

The original issue didn't have much discussion, so feel free to suggest changes/additions here. I will leave this PR open for a few days so everyone has the chance to suggest changes.

@leahcimto @jeffalo @gosoccerboy5 
