### PR TITLE
Relative URLs

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,8 +1,45 @@
 <!DOCTYPE html>
 <html lang=en>
 	<head>
-		<title>404 - Page Not Found</title>
 		<base>
+		<script>
+			let websitePath = "";
+	
+			function findNumberOfForwardSlashes(websiteFullPath){
+				numberOfForwardSlashes = 0;
+				for (let i = 0; i < websiteFullPath.length; i++) {
+					if (websiteFullPath[i] == '/'){
+						numberOfForwardSlashes += 1;
+					}
+				}
+				return numberOfForwardSlashes;
+			}
+	
+			if (window.location.host == ""){
+				// then contributor is using file://...
+				let path = window.location.pathname.substring(1 , window.location.pathname.length);
+				numberOfForwardSlashesInPath = findNumberOfForwardSlashes(path);
+			
+				let i = 0;
+				let forwardSlashesUntilNow = 0;
+				while (forwardSlashesUntilNow < numberOfForwardSlashesInPath) {
+					if (path[i] == '/') {
+						forwardSlashesUntilNow++;
+					}
+					websitePath += path[i];
+					i++;
+				}
+				console.log(websitePath);
+			}
+			else {
+				// then it is being run either on localhost or on the website. Then the baseHref will be window.location.origin
+				websitePath = window.location.origin;
+			}
+			
+			document.getElementsByTagName("base")[0].setAttribute("href", websitePath);
+			</script>
+		<title>404 - Page Not Found</title>
+		
 		<link rel="shortcut icon" type="image/png" href="resources/favicon.png">
 		<link rel="stylesheet" type="text/css" href="resources/stylesheet.css">
 
@@ -29,41 +66,6 @@
 		<script src="resources/imports.js" onload="reference('./');"></script>
 		<script src="resources/theme.js"></script>
 
-		<script>
-		let websitePath = "";
-
-		function findNumberOfForwardSlashes(websiteFullPath){
-			numberOfForwardSlashes = 0;
-			for (let i = 0; i < websiteFullPath.length; i++) {
-				if (websiteFullPath[i] == '/'){
-					numberOfForwardSlashes += 1;
-				}
-			}
-			return numberOfForwardSlashes;
-		}
-
-		if (window.location.host == ""){
-			let path = window.location.pathname.substring(1 , window.location.pathname.length);
-			// then contributor is using file://...
-			numberOfForwardSlashesInPath = findNumberOfForwardSlashes(path);
 		
-			let i = 0;
-			let forwardSlashesUntilNow = 0;
-			while (forwardSlashesUntilNow < numberOfForwardSlashesInPath) {
-				if (path[i] == '/') {
-					forwardSlashesUntilNow++;
-				}
-				websitePath += path[i];
-				i++;
-			}
-			console.log(websitePath);
-		}
-		else {
-			websitePath = window.location.origin;
-			// then it is being run either on localhost or on the website. Then the baseHref will be window.location.origin
-		}
-		
-		document.getElementsByTagName("base")[0].setAttribute("href", websitePath);
-		</script>
 	</body>
 </html>

--- a/404.html
+++ b/404.html
@@ -33,7 +33,22 @@
 			}
 			else {
 				// then it is being run either on localhost or on the website. Then the baseHref will be window.location.origin
-				websitePath = window.location.origin;
+				// ...except it only works when it is deployed on the TFH website.
+				let path = window.location.host + window.location.pathname;
+				numberOfForwardSlashesInPath = findNumberOfForwardSlashes(path);
+			
+				let i = 0;
+				let forwardSlashesUntilNow = 0;
+				while (forwardSlashesUntilNow < numberOfForwardSlashesInPath) {
+					if (path[i] == '/') {
+						forwardSlashesUntilNow++;
+					}
+					websitePath += path[i];
+					i++;
+				}
+				console.log(websitePath)
+				websitePath = window.location.protocol + "//" + websitePath;
+				console.log(websitePath);
 			}
 			
 			document.getElementsByTagName("base")[0].setAttribute("href", websitePath);

--- a/404.html
+++ b/404.html
@@ -2,7 +2,7 @@
 <html lang=en>
 	<head>
 		<title>404 - Page Not Found</title>
-		<base href="https://theforumhelpers.github.io"> <!--If making local changes, change the base tag to point to how your filesystem is set up-->
+		<base>
 		<link rel="shortcut icon" type="image/png" href="resources/favicon.png">
 		<link rel="stylesheet" type="text/css" href="resources/stylesheet.css">
 
@@ -28,5 +28,42 @@
 		</div>
 		<script src="resources/imports.js" onload="reference('./');"></script>
 		<script src="resources/theme.js"></script>
+
+		<script>
+		let websitePath = "";
+
+		function findNumberOfForwardSlashes(websiteFullPath){
+			numberOfForwardSlashes = 0;
+			for (let i = 0; i < websiteFullPath.length; i++) {
+				if (websiteFullPath[i] == '/'){
+					numberOfForwardSlashes += 1;
+				}
+			}
+			return numberOfForwardSlashes;
+		}
+
+		if (window.location.host == ""){
+			let path = window.location.pathname.substring(1 , window.location.pathname.length);
+			// then contributor is using file://...
+			numberOfForwardSlashesInPath = findNumberOfForwardSlashes(path);
+		
+			let i = 0;
+			let forwardSlashesUntilNow = 0;
+			while (forwardSlashesUntilNow < numberOfForwardSlashesInPath) {
+				if (path[i] == '/') {
+					forwardSlashesUntilNow++;
+				}
+				websitePath += path[i];
+				i++;
+			}
+			console.log(websitePath);
+		}
+		else {
+			websitePath = window.location.origin;
+			// then it is being run either on localhost or on the website. Then the baseHref will be window.location.origin
+		}
+		
+		document.getElementsByTagName("base")[0].setAttribute("href", websitePath);
+		</script>
 	</body>
 </html>

--- a/404.html
+++ b/404.html
@@ -33,22 +33,7 @@
 			}
 			else {
 				// then it is being run either on localhost or on the website. Then the baseHref will be window.location.origin
-				// ...except it only works when it is deployed on the TFH website.
-				let path = window.location.host + window.location.pathname;
-				numberOfForwardSlashesInPath = findNumberOfForwardSlashes(path);
-			
-				let i = 0;
-				let forwardSlashesUntilNow = 0;
-				while (forwardSlashesUntilNow < numberOfForwardSlashesInPath) {
-					if (path[i] == '/') {
-						forwardSlashesUntilNow++;
-					}
-					websitePath += path[i];
-					i++;
-				}
-				console.log(websitePath)
-				websitePath = window.location.protocol + "//" + websitePath;
-				console.log(websitePath);
+				websitePath = window.location.origin;
 			}
 			
 			document.getElementsByTagName("base")[0].setAttribute("href", websitePath);

--- a/resources/imports.js
+++ b/resources/imports.js
@@ -52,9 +52,3 @@ function denyPrivacy() {
 	localStorage.removeItem("FHacceptedDate");
 	window.location.href = "https://scratch.mit.edu/studios/3688309/";
 }
-
-function getWebsitePath() {
-	
-
-	return websitePath;
-}

--- a/resources/imports.js
+++ b/resources/imports.js
@@ -52,3 +52,9 @@ function denyPrivacy() {
 	localStorage.removeItem("FHacceptedDate");
 	window.location.href = "https://scratch.mit.edu/studios/3688309/";
 }
+
+function getWebsitePath() {
+	
+
+	return websitePath;
+}


### PR DESCRIPTION
### Resolves:
Resolves #163 

### Changes:
Removes the `href` attribute in the `<base>` tag. I added some javascript code to automatically add the href attribute to the base tag after the page loads and before other elements load.

### Local Tests:
Yes, tested locally using `localhost` and `file://` urls

### Things to note
The code isn't complete yet. That is why this PR is a draft. Note that the code is completely functional but there are a lot of things I could do to organise it (right now, it looks like a mess, sorry). I put a script tag at the top (and that was intentional because it had to load before other elements did). Also, I used script tags to add the JS code to `404.html`. Let me know if I should change that
