### PR TITLE
Add Application Info Page

### DIFF
--- a/apply/index.html
+++ b/apply/index.html
@@ -59,10 +59,10 @@
 				<li>Please do not copy and paste your old application if you are reapplying. We want to see that you have improved since your last application, and reposting the same application does not demonstrate this.</li>
 			</ul>
 
-			<h3>I submitted my application! Now what?</h3>
+			<h2>I submitted my application! Now what?</h2>
 			<p>Once you apply, a studio member will check out your application and see if you meet the requirements. If you don't, you will be rejected, in which case you can re-apply in a week. If your application contains all the required components, and you meet the requirements above, a member will post the link in the Forum Helpers Special Actions studio and it will enter a one week "Application Pending" window. During this time, your application will be discussed by current Forum Helpers. If your application gets less than four objections during this time, then your application will be accepted and you will be invited to the studio. If your application gets four or more objections during this time, then your application will be declined and you will be given some feedback on how to improve. If your application is declined, please wait at least one week before reapplying, and try to work on the feedback that you were given before reapplying.</p>
 
-			<h3>I've been accepted! Now what?</h3>
+			<h2>I've been accepted! Now what?</h2>
 			<p>Congratulations! You will know that you have been accepted because you will recieve an invite to the studio and a comment on your profile with the good news. Next, please leave a biography (500 characters or less) on the @TFH-Bios account so that it can be added to this website. Welcome to The Forum Helpers!</p>
 			<br>
 		</div>

--- a/apply/index.html
+++ b/apply/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang=en>
+	<head>
+		<title>How to Apply</title>
+		<link rel="shortcut icon" type="image/png" href="../resources/favicon.png">
+		<link rel="stylesheet" type="text/css" href="../resources/stylesheet.css">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<meta name="Description" content="How to apply to The Forum Helpers">
+
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-197061964-2"></script>
+		<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag(){dataLayer.push(arguments);}
+		gtag('js', new Date());
+
+		gtag('config', 'UA-197061964-2');
+		</script>
+	</head>
+
+	<body>
+		<header id="header"></header>
+
+		<div class="applyContent">
+		<br>
+			<h1>How to apply to The Forum Helpers</h1>
+			<p>Status: Applications are <span style="color: red">closed</span>, check back soon!</p>
+			<!--<p>Status: Applications are <span style="color: #1bc900">open</span></p>-->
+			<h2>Introduction</h2>
+			<p>
+				Thank you for your interest in applying to The Forum Helpers! We are always on the lookout for new members! Please ensure that you take the time to thoroughly read the application process below so that your application can be considered.
+			</p>
+
+			<h2>Requirements</h2>
+			<p>
+				The requirements to join The Forum Helpers exist to ensure that our members are ones that are dedicated to helping out on the forums, and that all of our members follow the community guidelines on and off the forums. The requirements to apply are:
+				<ul>
+					<li>You must have 500+ posts on the Scratch Discussion Forums.</li>
+					<li>You will not be added if any of your posts made within the month contain spam, trolling, necroposts, or generally breaking the rules.</li>
+					<li>If you are mainly active in Collaborations, Requests, Project Ideas, Things I'm Making and Creating, Things I'm Reading and Playing, New Scratchers, or Announcements, you may not apply unless you are active in other forums also.</li>
+				</ul>
+			</p>
+
+			<h2>I fit the requirements; how do I apply?</h2>
+			<p>
+				If you fit the requirements above, you are able to apply to The Forum Helpers. To apply, please fill out the following application and post it in <a class="FHULink" href="https://scratch.mit.edu/studios/3688309/comments/">our main studio</a>.
+			</p>
+				<ol>
+				<li> Which forums are you the most active in?</li>
+				<li>Provide links to 2 – 4 posts you made that you find the most constructive. (NOTE: They must NOT be a Sticky, iTopic, or any kind of guide)</li>
+				<li>Provide a link to your most recent forum post.</li>
+			</ol>
+			<p>Things to keep in mind when submitting your application. Not following these rules could result in your application being declined:</p>
+			<ul>
+				<li>Please do not use any third party service (eg. Ocular) to share deleted posts.</li>
+				<li>Please do not submit posts in your application that were made in the Collaborations, Requests, Project Ideas, Things I'm Making and Creating, Things I'm Reading and Playing, New Scratchers, or Announcements forums.</li>
+				<li>Please do not reply to discussion of your application in the Special Actions studio. You are welcome to read the discussion, but do not reply.</li>
+				<li>Please include the word <span id="codeWord">water</span> in your application to show that you have read and understand this entire page. Neglecting to include this word will cause your application to be auto-rejected.</li>
+				<li>Please do not copy and paste your old application if you are reapplying. We want to see that you have improved since your last application, and reposting the same application does not demonstrate this.</li>
+			</ul>
+
+			<h3>I submitted my application! Now what?</h3>
+			<p>Once you apply, a studio member will check out your application and see if you meet the requirements. If you don't, you will be rejected, in which case you can re-apply in a week. If your application contains all the required components, and you meet the requirements above, a member will post the link in the Forum Helpers Special Actions studio and it will enter a one week "Application Pending" window. During this time, your application will be discussed by current Forum Helpers. If your application gets less than four objections during this time, then your application will be accepted and you will be invited to the studio. If your application gets four or more objections during this time, then your application will be declined and you will be given some feedback on how to improve. If your application is declined, please wait at least one week before reapplying, and try to work on the feedback that you were given before reapplying.</p>
+
+			<h3>I've been accepted! Now what?</h3>
+			<p>Congratulations! You will know that you have been accepted because you will recieve an invite to the studio and a comment on your profile with the good news. Next, please leave a biography (500 characters or less) on the @TFH-Bios account so that it can be added to this website. Welcome to The Forum Helpers!</p>
+			<br>
+		</div>
+
+		<div class="privacyWarning" id="privacyWarning"></div>
+
+		<footer id="footer"></footer>
+		<script src="../resources/imports.js" onload='reference("../")'></script>
+		<script src="../resources/theme.js"></script>
+	</body>
+</html>

--- a/apply/index.html
+++ b/apply/index.html
@@ -35,8 +35,8 @@
 			<p>
 				The requirements to join The Forum Helpers exist to ensure that our members are ones that are dedicated to helping out on the forums, and that all of our members follow the community guidelines on and off the forums. The requirements to apply are:
 				<ul>
-					<li>You must have 500+ posts on the Scratch Discussion Forums.</li>
-					<li>You will not be added if any of your posts made within the month contain spam, trolling, necroposts, or generally breaking the rules.</li>
+					<li>You must have 500+ posts on the Scratch Discussion Forums.</li><br>
+					<li>You will not be added if any of your posts made within the month contain spam, trolling, necroposts, or generally breaking the rules.</li><br>
 					<li>If you are mainly active in Collaborations, Requests, Project Ideas, Things I'm Making and Creating, Things I'm Reading and Playing, New Scratchers, or Announcements, you may not apply unless you are active in other forums also.</li>
 				</ul>
 			</p>
@@ -46,16 +46,16 @@
 				If you fit the requirements above, you are able to apply to The Forum Helpers. To apply, please fill out the following application and post it in <a class="FHULink" href="https://scratch.mit.edu/studios/3688309/comments/">our main studio</a>.
 			</p>
 				<ol>
-				<li> Which forums are you the most active in?</li>
-				<li>Provide links to 2 – 4 posts you made that you find the most constructive. (NOTE: They must NOT be a Sticky, iTopic, or any kind of guide)</li>
+				<li> Which forums are you the most active in?</li><br>
+				<li>Provide links to 2 – 4 posts you made that you find the most constructive. (NOTE: They must NOT be a Sticky, iTopic, or any kind of guide)</li><br>
 				<li>Provide a link to your most recent forum post.</li>
 			</ol>
 			<p>Things to keep in mind when submitting your application. Not following these rules could result in your application being declined:</p>
 			<ul>
-				<li>Please do not use any third party service (eg. Ocular) to share deleted posts.</li>
-				<li>Please do not submit posts in your application that were made in the Collaborations, Requests, Project Ideas, Things I'm Making and Creating, Things I'm Reading and Playing, New Scratchers, or Announcements forums.</li>
-				<li>Please do not reply to discussion of your application in the Special Actions studio. You are welcome to read the discussion, but do not reply.</li>
-				<li>Please include the word <span id="codeWord">water</span> in your application to show that you have read and understand this entire page. Neglecting to include this word will cause your application to be auto-rejected.</li>
+				<li>Please do not use any third party service (eg. ocular) to share deleted posts.</li><br>
+				<li>Please do not submit posts in your application that were made in the Collaborations, Requests, Project Ideas, Things I'm Making and Creating, Things I'm Reading and Playing, New Scratchers, or Announcements forums.</li><br>
+				<li>Please do not reply to discussion of your application in the Special Actions studio. You are welcome to read the discussion, but do not reply.</li><br>
+				<li>Please include the word <span id="codeWord">water</span> in your application to show that you have read and understand this entire page. Neglecting to include this word will cause your application to be auto-rejected.</li><br>
 				<li>Please do not copy and paste your old application if you are reapplying. We want to see that you have improved since your last application, and reposting the same application does not demonstrate this.</li>
 			</ul>
 
@@ -63,7 +63,7 @@
 			<p>Once you apply, a studio member will check out your application and see if you meet the requirements. If you don't, you will be rejected, in which case you can re-apply in a week. If your application contains all the required components, and you meet the requirements above, a member will post the link in the Forum Helpers Special Actions studio and it will enter a one week "Application Pending" window. During this time, your application will be discussed by current Forum Helpers. If your application gets less than four objections during this time, then your application will be accepted and you will be invited to the studio. If your application gets four or more objections during this time, then your application will be declined and you will be given some feedback on how to improve. If your application is declined, please wait at least one week before reapplying, and try to work on the feedback that you were given before reapplying.</p>
 
 			<h2>I've been accepted! Now what?</h2>
-			<p>Congratulations! You will know that you have been accepted because you will recieve an invite to the studio and a comment on your profile with the good news. Next, please leave a biography (500 characters or less) on the @TFH-Bios account so that it can be added to this website. Welcome to The Forum Helpers!</p>
+			<p>Congratulations! You will know that you have been accepted because you will recieve an invite to the studio and a comment on your profile with the good news. Next, please leave a biography (500 characters or less) on the <a href="https://scratch.mit.edu/users/TFH-Bios/" class="FHULink" target="_blank">@TFH-Bios</a> account so that it can be added to this website. Welcome to The Forum Helpers!</p>
 			<br>
 		</div>
 

--- a/contributors/index.html
+++ b/contributors/index.html
@@ -27,10 +27,10 @@
 			<div class="creditsPeople" id="creditsPeople">
 
 			</div>
-			
+
 			<div class="creditsServices">
 				<h2>Thank you to the following services and their contributors that help make this site possible.</h2>
-				<p><a href="https://ocular.jeffalo.net/" class="FHULink">Ocular by Jeffalo</a> - Used to get Ocular Statuses for the List of Forum Helpers Page.</p>
+				<p><a href="https://ocular.jeffalo.net/" class="FHULink">ocular by Jeffalo</a> - Used to get ocular statuses for the List of Forum Helpers Page.</p>
 				<p><a href="https://scratchdb.lefty.one/" class="FHULink">ScratchDB by DatOneLefty</a> - Used to get post counts for the List of Forum Helpers Page.</p>
 				<p><a href="https://analytics.google.com/analytics/web/" class="FHULink">Google Analytics</a> - Used to get statistics about the usage of the site.</p>
 				<p><a href="https://scratch.mit.edu/" class="FHULink">Scratch Sprite Library</a> - Taco Wizard Sprite used on the 404 page. Scratch is a project of the Scratch Foundation, in collaboration with the Lifelong Kindergarten Group at the MIT Media Lab. It is available for free at https://scratch.mit.edu/</p>
@@ -38,7 +38,7 @@
 			<br>
 			<h3>Thank you additionally to everyone who submitted biographies for our <a href="https://theforumhelpers.github.io/forumhelpers/" class="FHULink">List of Forum Helpers Page</a>.</h3>
 			<h3>Interested in contributing? Visit our <a href="https://github.com/theforumhelpers/theforumhelpers.github.io" class="FHULink">GitHub Repository</a>!</h3>
-		
+
 		</div>
 
 		<div class="privacyWarning" id="privacyWarning"></div>

--- a/index.html
+++ b/index.html
@@ -22,16 +22,18 @@
 		<header id="header"></header>
 
 		<div class="homeContent">
-		<br>
+			<br>
+			<div class="homeAlert" id="homeAlert">
+				<p>Interested in applying to The Forum Helpers? Check out our <a class="FHULink" href="apply">how to apply page</a>.</p>
+				<button class="closeAlert" onclick="document.getElementById('homeAlert').style.display = 'none';">X</button>
+			</div>
 			<h1>Welcome to the website for the Scratch Forum Helpers!</h1>
 			<h2>Who are we?</h2>
 			<p class="homeAnswers">We are a small group of people on <a href="https://scratch.mit.edu" class="FHULink">Scratch</a> who help around on the <a href="https://scratch.mit.edu/discuss/" class="FHULink">Discussion Forums</a> by answering questions, responding to bug reports, and giving our thoughts on suggestions made by Scratchers from all over the world. We don't "police" the forums, but we try our best to assist other users whenever we can.<br><br>All of us are members of <a href="https://scratch.mit.edu/studios/3688309/" class="FHULink">this studio</a>.</p>
-			<h2>What forums are the Forum Helpers most active in?</h2>
-			<p class="homeAnswers">We generally frequent the <a href="https://scratch.mit.edu/discuss/1/" class="FHULink">Suggestions</a>, <a href="https://scratch.mit.edu/discuss/3/" class="FHULink">Bugs And Glitches</a>, <a href="https://scratch.mit.edu/discuss/4/" class="FHULink">Questions About Scratch</a>, and <a href="https://scratch.mit.edu/discuss/7/" class="FHULink">Help With Scripts</a> forums.
-			<h2>I'm interested in becoming a Forum Helper! How do I apply?</h2>
-			<p class="homeAnswers">We're glad that you're interested in applying! We are always on the lookout for new members! However, there is a requirement, which is that you must have at least 500 posts to apply. In order to apply, please go to the <a href="https://scratch.mit.edu/studios/3688309/" class="FHULink">Forum Helpers Studio</a>, and fill out the application listed in the description of the studio. Remember to read all the rules in the studio description closely.</p>
-			<h3>I submitted my application! Now what?</h3>
-			<p class="homeAnswers">Once you apply, a manager of the studio will check out your application and see if you meet the requirements. If you don't, you will be rejected in which case you can re-apply in a week. If your application contains all the required components, a manager will post the link in the Forum Helpers Special Actions studio and it will enter a one week "Application Pending" window. During this time, your application will be discussed by current Forum Helpers. If no one objects to you joining during this time, then your application will be accepted and you will be invited to the studio. If one or more managers object to you joining, then your application will be declined and you will be given some feedback on how to improve. If your application is declined, please wait at least one week before reapplying.</p>
+			<h2>What forums are we most active in?</h2>
+			<p class="homeAnswers">We generally frequent the <a href="https://scratch.mit.edu/discuss/1/" class="FHULink">Suggestions</a>, <a href="https://scratch.mit.edu/discuss/3/" class="FHULink">Bugs And Glitches</a>, <a href="https://scratch.mit.edu/discuss/4/" class="FHULink">Questions About Scratch</a>, and <a href="https://scratch.mit.edu/discuss/7/" class="FHULink">Help With Scripts</a> forums.</p>
+			<h2>How can I join The Forum Helpers?</h2>
+			<p class="homeAnswers">For a detailed explanation on how to join our group, please check out the <a class="FHULink" href="apply">how to apply page</a>.</p>
 			<br>
 		</div>
 

--- a/resources/imports.js
+++ b/resources/imports.js
@@ -6,10 +6,12 @@ function reference(link) {
 		<img src="${link}resources/icon.png" width="64px" height="64px" class="navHomeIcon">
 	</a>
 	<h1 class="navTitle">The Forum Helpers</h1>
-	<a href="${link}forumhelpers" class="navButton" target="_parent">List Of Forum Helpers</a>
-	<a href="https://scratch.mit.edu/studios/3688309/" class="navButton" target="_blank">Our Scratch Studio</a>
-	<a href="https://theforumhelpers.github.io/QuickReply/" class="navButton" target="_parent">QuickReply</a>
+	<a href="${link}apply" class="navButton">Apply</a>
+	<a href="${link}forumhelpers" class="navButton">List Of Forum Helpers</a>
+	<a href="https://scratch.mit.edu/studios/3688309/" class="navButton">Our Scratch Studio</a>
+	<a href="https://theforumhelpers.github.io/QuickReply/" class="navButton">QuickReply</a>
 	<div class="expandableDropdown" onmouseover="expandHeader()" onmouseout="collapseHeader()">
+		<a class="expandableLink" href="${link}apply">Apply</a>
 		<a class="expandableLink" href="${link}forumhelpers">List Of Forum Helpers</a>
 		<a class="expandableLink" href="https://scratch.mit.edu/studios/3688309/">Our Scratch Studio</a>
 		<a class="expandableLink" href="https://theforumhelpers.github.io/QuickReply/">QuickReply</a>

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -113,7 +113,9 @@ header {
 
 .navTitle {
 	float: left;
-	width: 50%;
+	width: 37.5%;
+	min-width: 180px;
+	box-sizing: border-box;
 	height: 100%;
 	margin-top: 0px;
 	padding-top: 10px;
@@ -147,6 +149,7 @@ header {
 	margin-right: 10px;
 	margin-top: 10px;
 	background-image: url("expandable.svg");
+	z-index: 100;
 }
 
 .expandableLink {
@@ -165,6 +168,7 @@ header {
 	position: relative;
 	top: 60px;
 	left: 10px;
+	z-index: 100;
 }
 
 @media only screen and (max-width: 1154px) {
@@ -180,15 +184,16 @@ header {
 		display: inline-block;
 		font-size: 22px;
 	}
+	@media only screen and (max-width: 1000px) {
+		/* Hide nav links */
+		.navButton {
+			display: none;
+		}
 
-	/* Hide nav links */
-	.navButton {
-		display: none;
-	}
-
-	/* Show dropdown instead */
-	.expandableDropdown {
-		display: inline;
+		/* Show dropdown instead */
+		.expandableDropdown {
+			display: inline;
+		}
 	}
 }
 /* /navbar */
@@ -201,6 +206,24 @@ header {
 	text-align: center;
 	margin-top: 0px;
 	font-family: Arial, sans-serif;
+}
+
+.homeAlert {
+	background-color: var(--secondary);
+	padding: 10px;
+	border-radius: 15px;
+	width: 60%;
+	margin: auto;
+	position: relative;
+	color: var(--textSecondary);
+	z-index: 5;
+}
+
+.closeAlert {
+	position: absolute;
+	right: 5px;
+	top: 5px;
+	margin: 5px;
 }
 
 .homeAnswers {
@@ -404,6 +427,19 @@ hr {
 	color: black;
 }
 /* /Privacy */
+
+/* Apply */
+.applyContent {
+	padding: 0px 30px;
+	box-sizing: border-box;
+	color: var(--textPrimary);
+	font-size: 20px;
+	width: 100%;
+	text-align: left;
+	margin-top: 0px;
+	font-family: Arial, sans-serif;
+}
+/* /Apply */
 
 /* 404 (had to use lost since css won't use numbers at the start of class names) */
 .lostTitle {


### PR DESCRIPTION
### Resolves:
Resolves #264 

### Changes:
-Add a page with information for potential applicants.
-Applications are currently closed, which is reflected on this page.
-Add a link to the application page in the header.
-Add an information box to the main page directing users to the application page.
-Remove application information from the main page.
-Some small CSS changes to accommodate the changes above.

### Local Tests:
Tested locally

I'll leave this open for a few days to allow a few people to review it. The content is still subject to change, I just basically took what was in the description before and added it to this page.

@jeffalo @leahcimto @gosoccerboy5 