### PR TITLE
Create .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
### Resolves:

fixes #282
### Changes:

adds an [editorconfig](http://editorconfig.org) file that will maintain the default tabs, but views them as 4 spaces
### Local Tests:

I viewed a file on github's web interface and the tabs showed up as 4 spaces. it looks fine.


note - maybe we should remind newcomers that the repo uses tabs?