### PR TITLE
Make the CONTRIBUTING.md file more 'visible'

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Resolves:
 
-_What Github issue does this resolve (please include link)? Do NOT create a Pull Request for a major issue that you have not been assigned to unless you are a part of the editors team for this repo._
+_What Github issue does this resolve (please include link)? Do NOT create a Pull Request for a major issue that you have not been assigned to unless you are a part of the editors team for this repo. For more information, read the [CONTRIBUTING.md](CONTRIBUTING.md) file._
 
 ### Changes:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Resolves:
 
-_What Github issue does this resolve (please include link)? Do NOT create a Pull Request for a major issue that you have not been assigned to unless you are a part of the editors team for this repo. For more information, read the [CONTRIBUTING.md](../CONTRIBUTING.md) file._
+_What Github issue does this resolve (please include link)? Do NOT create a Pull Request for a major issue that you have not been assigned to unless you are a part of the editors team for this repo. For more information, please read the [Contributing Guidelines](../CONTRIBUTING.md)._
 
 ### Changes:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Resolves:
 
-_What Github issue does this resolve (please include link)? Do NOT create a Pull Request for a major issue that you have not been assigned to unless you are a part of the editors team for this repo. For more information, read the [CONTRIBUTING.md](CONTRIBUTING.md) file._
+_What Github issue does this resolve (please include link)? Do NOT create a Pull Request for a major issue that you have not been assigned to unless you are a part of the editors team for this repo. For more information, read the [CONTRIBUTING.md](../CONTRIBUTING.md) file._
 
 ### Changes:
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # The Forum Helpers
 The main site for the Scratch group "The Forum Helpers".
+
+# Want to contribute?
+First, read the [CONTRIBUTING.md](CONTRIBUTING.md) to understand this repository's guidelines.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 The main site for the Scratch group "The Forum Helpers".
 
 # Want to contribute?
-First, read the [CONTRIBUTING.md](CONTRIBUTING.md) to understand this repository's guidelines.
+First, read the [Contributing Guidelines](CONTRIBUTING.md) to understand how you can submit ideas and changes to this repository.


### PR DESCRIPTION
### Resolves:
Resolves #290.

### Changes:

 - Link the CONTRIBUTING.md file in the README.md
 - Link it also in the PR template

This way, people are more likely to know about and read the CONTRIBUTING.md file.
### Local Tests:

Tested the link in the README.md file. It works both locally and on Github's web interface. Also tested the link in the PULL_REQUEST_TEMPLATE.md file locally. It works, I think. [(Thanks!)](https://stackoverflow.com/a/24028813/15938577)

@Accio1 or @leahcimto, if you don't like the text I've used, feel free to edit it.