### PR TITLE
Remove Google Analytics

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,16 +5,6 @@
 		<base href="https://theforumhelpers.github.io"> <!--If making local changes, change the base tag to point to how your filesystem is set up-->
 		<link rel="shortcut icon" type="image/png" href="resources/favicon.png">
 		<link rel="stylesheet" type="text/css" href="resources/stylesheet.css">
-
-		<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-197061964-2"></script>
-		<script>
-		window.dataLayer = window.dataLayer || [];
-		function gtag(){dataLayer.push(arguments);}
-		gtag('js', new Date());
-
-		gtag('config', 'UA-197061964-2');
-		</script>
 	</head>
 	<body>
 		<header id="header"></header>

--- a/apply/index.html
+++ b/apply/index.html
@@ -6,16 +6,6 @@
 		<link rel="stylesheet" type="text/css" href="../resources/stylesheet.css">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="Description" content="How to apply to The Forum Helpers">
-
-		<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-197061964-2"></script>
-		<script>
-		window.dataLayer = window.dataLayer || [];
-		function gtag(){dataLayer.push(arguments);}
-		gtag('js', new Date());
-
-		gtag('config', 'UA-197061964-2');
-		</script>
 	</head>
 
 	<body>

--- a/contributors/index.html
+++ b/contributors/index.html
@@ -6,16 +6,6 @@
 		<link rel="stylesheet" type="text/css" href="../resources/stylesheet.css">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="Description" content="List of people who helped develop this site">
-
-		<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-197061964-2"></script>
-		<script>
-		window.dataLayer = window.dataLayer || [];
-		function gtag(){dataLayer.push(arguments);}
-		gtag('js', new Date());
-
-		gtag('config', 'UA-197061964-2');
-		</script>
 	</head>
 
 	<body>
@@ -32,7 +22,6 @@
 				<h2>Thank you to the following services and their contributors that help make this site possible.</h2>
 				<p><a href="https://ocular.jeffalo.net/" class="FHULink">ocular by Jeffalo</a> - Used to get ocular statuses for the List of Forum Helpers Page.</p>
 				<p><a href="https://scratchdb.lefty.one/" class="FHULink">ScratchDB by DatOneLefty</a> - Used to get post counts for the List of Forum Helpers Page.</p>
-				<p><a href="https://analytics.google.com/analytics/web/" class="FHULink">Google Analytics</a> - Used to get statistics about the usage of the site.</p>
 				<p><a href="https://scratch.mit.edu/" class="FHULink">Scratch Sprite Library</a> - Taco Wizard Sprite used on the 404 page. Scratch is a project of the Scratch Foundation, in collaboration with the Lifelong Kindergarten Group at the MIT Media Lab. It is available for free at https://scratch.mit.edu/</p>
 			</div>
 			<br>

--- a/forumhelpers/index.html
+++ b/forumhelpers/index.html
@@ -6,16 +6,6 @@
 		<link rel="stylesheet" type="text/css" href="../resources/stylesheet.css">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="Description" content="The list of all the Forum Helpers who are in the Scratch Forum Helpers studio, as well as their biographies.">
-
-		<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-197061964-2"></script>
-		<script>
-		window.dataLayer = window.dataLayer || [];
-		function gtag(){dataLayer.push(arguments);}
-		gtag('js', new Date());
-
-		gtag('config', 'UA-197061964-2');
-		</script>
 	</head>
 
 	<body onload="getData('managers')">

--- a/index.html
+++ b/index.html
@@ -6,16 +6,6 @@
 		<link rel="stylesheet" type="text/css" href="resources/stylesheet.css">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="Description" content="The official website for the Scratch Forum Helpers. This contains information about who we are and what we do.">
-
-		<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-197061964-2"></script>
-		<script>
-		window.dataLayer = window.dataLayer || [];
-		function gtag(){dataLayer.push(arguments);}
-		gtag('js', new Date());
-
-		gtag('config', 'UA-197061964-2');
-		</script>
 	</head>
 
 	<body>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -6,16 +6,6 @@
 		<link rel="stylesheet" type="text/css" href="../resources/stylesheet.css">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="description" content="The Forum Helpers site privacy policy.">
-
-		<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-197061964-2"></script>
-		<script>
-		window.dataLayer = window.dataLayer || [];
-		function gtag(){dataLayer.push(arguments);}
-		gtag('js', new Date());
-
-		gtag('config', 'UA-197061964-2');
-		</script>
 	</head>
 
 	<body>
@@ -25,19 +15,15 @@
 			<h1 style="text-align: center;">Privacy</h1>
 			<h3>Google Analytics</h3>
 			<ul>
-				<li>In order to gain statistics about the number of people who are using our site, and how people interact with the site, we use Google Analytics to track page views and interactions.</li><br>
-				<li>Google Analytics tracks your website usage by placing cookies on your computer and by continuing to use this site, you agree to the use of these cookies.</li><br>
-				<li>We recommend that you check out <a href="https://policies.google.com/technologies/partner-sites">How Google uses data when you use our partners' sites or apps</a> for additional information about Google Analytics.</li><br>
-				<li>Examples of data that Google Analytics may collect include: IP Address, Operating System, the amount of time that you spend on each page, and what you click while on the page.</li><br>
-				<li>This data is not shared or sold with anybody besides site developers, who use it to improve the site based on usage statistics.</li><br>
-				<li>If you do not agree to the use of Google Analytics, please discontinue your use of this site, or look into other options that you can use to disable Google Analytics, such as blocking cookies that come from Google Analytics.</li>
+				<li><b>This site no longer uses Google Analytics as of July 19th 2022.</b></li><br>
+				<li>Google Analytics was previously used from May 16th 2021-July 19th 2022 in order to gain a better understanding of the userbase of the site, including information such as what percentage of users visited the site from a mobile device.</li><br>
+				<li>Google Analytics was removed due to privacy concerns.</li><br>
+				<li>A more privacy friendly alternative to Google Analytics may be implemented in the future.</li>
 			</ul>
 
 			<h3>Other</h3>
 			<ul>
-				<li>Aside from Google Analytics, this site also stores two cookies on your computer which save whether or not you have agreed to the use of Google Analytics, and the date that you agreed.</li><br>
-				<li>This cookie expires each month, so you will have to re-accept the use of Google Analytics when you visit our site in a month that you have not yet accepted.</li><br>
-				<li>We also store one cookie which does not expire that stores your theme choice, as well as one that stores your search options.</li><br>
+				<li>We store two cookies on your computer which do not expire. One stores your theme choice, and the other stores your search options.</li><br>
 				<li>Questions? Feel free to contact us by <a href="https://github.com/theforumhelpers/theforumhelpers.github.io/discussions/new?category=q-a">opening a discussion</a> on our GitHub repository.</li>
 			</ul>
 		</div>

--- a/resources/imports.js
+++ b/resources/imports.js
@@ -24,36 +24,10 @@ function reference(link) {
 		<a onclick="changeTheme()" class="changeTheme" id="changeTheme">Change Theme</a><br>
 		<p><a href="${link}contributors/" class="FHULink" target="_parent">Contributors</a></p>
 		<p><a href="https://github.com/theforumhelpers/theforumhelpers.github.io" class="FHULink" target="_parent">Github Repository</a></p>
+		<p><a href="${link}privacy/" class="FHULink" target="_parent">Privacy Policy</a></p>
 		<p>Be moist <img src="https://cdn.scratch.mit.edu/scratchr2/static/__4f1f321e080ee4987f163566ecc0dd26__/djangobb_forum/img/smilies/cool.png"></p>
-		<p style="font-size: 12px;">This site uses Google Analytics. Check out our <a href="${link}privacy/" class="FHULink" target="_parent">Privacy Policy</a> for more information</p>
 	</div>`
 	document.getElementById("footer").innerHTML = footerContent;
-
-	const privacyContent = `
-	<p style="margin:0px;">This site uses Google Analytics.<br>Check out our <a href="${link}privacy/" class="FHULink" target="_parent">Privacy Policy</a> for more information.</p><br>
-	<button class="privacyButton" onclick="acceptPrivacy()">Okay</button> <button class="privacyButton" onclick="denyPrivacy()">Leave Site</button>`
-	var currentDate = new Date();
-	var currentMonth = currentDate.getMonth();
-	//var currentDay = currentDate.getDate();
-	var storedDate = new Date(localStorage.getItem("FHacceptedDate"));
-	var storedMonth = storedDate.getMonth() ?? 100;
-	//var storedDay = storedDate.getDate() ?? 100;
-	if (currentMonth != storedMonth /*|| storedDay+7 < currentDay*/) {
-		document.getElementById("privacyWarning").innerHTML = privacyContent;
-	}
-}
-
-function acceptPrivacy() {
-	var setDate = new Date();
-	localStorage.setItem("FHacceptedAnalytics", "true");
-	localStorage.setItem("FHacceptedDate", setDate);
-	document.getElementById("privacyWarning").style.display = "none";
-}
-
-function denyPrivacy() {
-	localStorage.removeItem("FHacceptedAnalytics");
-	localStorage.removeItem("FHacceptedDate");
-	window.location.href = "https://scratch.mit.edu/studios/30136012/";
 }
 
 function expandHeader() {


### PR DESCRIPTION
### Resolves:
Resolves privacy concerns that users may have had
Closes #304 
Closes #271 

### Changes:
- Remove Google Analytics tags from each page
- Remove privacy warning
- Remove Google Analytics from the contributors page
- Modify privacy policy to reflect these changes

### Local Tests:
Tested locally

@leahcimto 
