### PR TITLE
Make header title a link

### DIFF
--- a/resources/imports.js
+++ b/resources/imports.js
@@ -2,10 +2,10 @@ var referenceLink = "";
 function reference(link) {
 	referenceLink = link;
 	const headerContent = `
-	<a href="${link}" target="_parent">
+	<a href="${link}" target="_parent" class="headerHomeLink">
 		<img src="${link}resources/icon.png" width="64px" height="64px" class="navHomeIcon">
+		<h1 class="navTitle">The Forum Helpers</h1>
 	</a>
-	<h1 class="navTitle">The Forum Helpers</h1>
 	<a href="${link}apply" class="navButton">Apply</a>
 	<a href="${link}forumhelpers" class="navButton">List Of Forum Helpers</a>
 	<a href="https://scratch.mit.edu/studios/30136012/" class="navButton">Our Scratch Studio</a>

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -70,13 +70,13 @@ a {
 	text-decoration: underline;
 }
 
-a:visited:not(.navButton):visited {
+a:visited:not(.navButton, .headerHomeLink):visited {
 	color: inherit;
 	background-color: inherit;
 	text-decoration: underline;
 }
 
-a:hover:not(.navButton):hover {
+a:hover:not(.navButton, .headerHomeLink):hover {
 	color: var(--linkHover);
 	background-color: inherit;
 	text-decoration: underline;
@@ -117,7 +117,7 @@ header {
 
 .navTitle {
 	float: left;
-	width: 37.5%;
+	max-width: 37.5%;
 	min-width: 180px;
 	box-sizing: border-box;
 	height: 100%;


### PR DESCRIPTION
### Resolves:

Resolves #333 

### Changes:

- Make the title in the header a link by wrapping the <a> tag around it
- Make max-width of the header title 37.5% so that the link doesn't overflow the text

### Local Tests:

Tested locally

@penguinmoose this was your issue so feel free to review.
