### PR TITLE
Loading text with brackets around it on apply page

### DIFF
--- a/apply/index.html
+++ b/apply/index.html
@@ -14,7 +14,7 @@
 		<div class="applyContent">
 		<br>
 			<h1>How to apply to The Forum Helpers</h1>
-			<p>Status: Applications are <span id="applicationStatus">Loading application status...</span></p>
+			<p>Status: Applications are <span id="applicationStatus">[Loading application status...]</span></p>
 
 			<h2>Introduction</h2>
 			<p>


### PR DESCRIPTION
### Resolves:
No issue was resolved, however, upon merging #339, placeholder text was added to places that were blank when the Dashboard API is loading. It looks weird when it says "Applications are Application status loading...", so this fixes that by adding square brackets around "Application status loading". This maybe could also be fixed by changing the wording to "Application status: closed/open/loading", however, this could be a fix for now if that's okay.

### Changes:

See above

### Local Tests:

None
