### PR TITLE
Change link “ocular status” in TFH list

### DIFF
--- a/forumhelpers/index.html
+++ b/forumhelpers/index.html
@@ -24,7 +24,7 @@
 		<br>
 		<h1 class="forumHelpersHeader">Current Forum Helpers</h1>
 		<br>
-		<h3 class="forumHelpersHeader">Below is a list of current Forum Helpers, along with their profile picture, biography, and <a href="https://ocular.jeffalo.net/">Ocular Status</a>.</h3>
+		<h3 class="forumHelpersHeader">Below is a list of current Forum Helpers, along with their profile picture, biography, and <a href="https://ocular.jeffalo.net/docs/about#what-is-an-ocular-status">Ocular Status</a>.</h3>
 		<br>
 		<p class="forumHelpersHeader">There are currently <span id="managersNumber"></span> Managers and <span id="curatorsNumber"></span> Curators in our studio, for a total of <span id="totalNumber"></span> members.</p>
 		<!--<h4 style="margin-left: 10px;"><img src="/resources/coder.png" alt="coder" style="width:30px;height:30px;vertical-align:middle"> Indicates that that person has helped code the website.</h4>-->


### PR DESCRIPTION
### Resolves:

Issue #337

### Changes:

On the list of Forum Helpers, there is a link that currently goes to Ocular - “…below is a list of forum helpers, along with their biography, …
, and **Ocular Status**”. This changes the link to go to the about page of Ocular.

### Local Tests:

I used an online HTML editor and it looked ok.

I think it would be even better if the link went to the page with the ocular status section highlighted. The link can be easily generated using Chrome. What do you think?

